### PR TITLE
Embedded language, small-step evaluator and examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ Makefile.conf
 *.vok
 *.vos
 .lia.cache
+*.mli
+*.vio

--- a/Evaluator.v
+++ b/Evaluator.v
@@ -1,6 +1,7 @@
 Require Export SystemFR.Trees.
 Require Export SystemFR.Syntax.
 Require Export SystemFR.Freshness.
+(* Require Import SystemFR.Notations. *)
 
 
 Fixpoint isValue (t: tree) : bool :=
@@ -8,21 +9,24 @@ Fixpoint isValue (t: tree) : bool :=
     | lvar _ _ => true
     | fvar _ _ => true
     | uu => true
-    | tsize e => (isValue e)
+    | ttrue => true
+    | tfalse => true
     | pp e1 e2 => andb (isValue e1) (isValue e2)
     | _ => false (* Lacks a looooot of terms *) end.
 
-Definition optionApp (t : tree -> tree) (v : option tree) : option tree :=
-  match v with
-    | None => None
-    | Some v' => Some (t v') end.
-
-Fixpoint eval (t: tree): (option tree) :=
+Fixpoint ss_eval (t: tree): (option tree) :=
   match t with
-    | pi1 (pp e1 e2) => Some e1
+    | pi1 (pp e1 e2) => match (isValue e1, isValue e2) with
+                         | (true, true) => Some e1
+                         | (true, false) => option_map (fun e => pi1 (pp e1 e)) (ss_eval e2)
+                         | (false, _) => option_map (fun e => pi1 (pp e e2)) (ss_eval e1)
+                       end
     | pp e1 e2 => match (isValue e1) with
-                   | true => optionApp (pp e1) (eval e2)
-                   | false => optionApp (fun e => pp e e2) (eval e1) end
+                   | true => option_map (pp e1) (ss_eval e2)
+                   | false => option_map (fun e => pp e e2) (ss_eval e1) end
     | _ => None end.
 
-Eval compute in (eval (pi1 (pp uu uu))).
+Eval compute in (ss_eval (pp (pi1 (pp ttrue uu)) uu)).
+Eval compute in (ss_eval (pi1 (pp ttrue uu))).
+
+Search (_ -> option _).

--- a/Evaluator.v
+++ b/Evaluator.v
@@ -195,7 +195,6 @@ match goal with
   | H: context[getApp ?t = _ ] |- _ => let fresh := fresh "getApp" in destruct (getApp t) (* eqn:fresh *)
   | H: context[_ = getApp ?t ] |- _ => let fresh := fresh "getApp" in destruct (getApp t) (* eqn:fresh *)
 end. (* match on type of t = sig *)
-
 Ltac destruct_ss_eval :=
   match goal with
     | H: context[ss_eval ?t] |- _ => destruct (ss_eval t) end.
@@ -222,7 +221,7 @@ Ltac ss_eval_step :=
 Lemma ss_eval_correct2: forall t t',(pfv t term_var = nil) -> scbv_step t t' ->  ss_eval t = Some t'.
   intros.
   induction H0 ;
-    repeat light || options || invert_constructor_equalities || ss_eval_step || destruct_sig || instantiate_eq_refl || list_utils || bools || rewrite <- isValueCorrect in * ||  eauto using ss_eval_step, fv_nil_top_level_var with smallstep values || destruct_match.
+    repeat light || options || invert_constructor_equalities || ss_eval_step || destruct_sig || instantiate_eq_refl || list_utils || bools || rewrite <- isValueCorrect in * ||  eauto using fv_nil_top_level_var with smallstep values || destruct_match.
 Qed.
 
 Lemma ss_eval_correct1: forall t t', ss_eval t = Some t' -> (pfv t term_var = nil) -> scbv_step t t'.

--- a/Evaluator.v
+++ b/Evaluator.v
@@ -14,10 +14,14 @@ Fixpoint isValue (t: tree) : bool :=
     | tleft e1 => (isValue e1)
     | tright e1 => (isValue e1)
     | zero => true
-    | succ e1 => (isValue e1)
-    | _ => false (* Lacks a looooot of terms *) end.
-
-Fixpoint isNat (t : tree) : bool :=
+    | succ e1 => (isNat e1)
+    | lambda _ _ => true
+    | notype_lambda _ => true
+    | err _ => true
+    | notype_err => true
+    | tfix _ _  => true
+    | _ => false end
+with isNat (t : tree) : bool :=
   match t with
     | zero => true
     | succ t1 => (isNat t1)
@@ -64,8 +68,9 @@ Fixpoint ss_eval (t: tree) {struct t}: (option tree) :=
     | tleft t => option_map tleft (ss_eval t)
     | tright t => option_map tright (ss_eval t)
                            
-    | _ => None end.
-
+    | _ => None
+  end.
+           
 
 Fixpoint bs_eval (t: tree): (option tree) :=
   match t with

--- a/Evaluator.v
+++ b/Evaluator.v
@@ -4,6 +4,9 @@ Require Export SystemFR.Freshness.
 Require Export SystemFR.Notations.
 Import Notations.UnTyped.
 Require Export SystemFR.PrimitiveSize.
+Require Export SystemFR.SmallStep.
+
+Open Scope bool_scope.
 
 Fixpoint isNat (t : tree) : bool :=
   match t with
@@ -13,8 +16,8 @@ Fixpoint isNat (t : tree) : bool :=
 end.
 Fixpoint isValue (t: tree) : bool :=
   match t with
-    | lvar _ _ => true
-    | fvar _ _ => true
+    (*| lvar _ _ => true
+    | fvar _ _ => true *)
     | uu => true
     | ttrue => true
     | tfalse => true
@@ -22,14 +25,53 @@ Fixpoint isValue (t: tree) : bool :=
     | tleft e1 => (isValue e1)
     | tright e1 => (isValue e1)
     | zero => true
-    | succ e1 => (isNat e1)
-    | lambda _ _ => true
+    | succ e1 => (isValue e1)
     | notype_lambda _ => true
-    | err _ => true
-    | notype_err => true
-    | tfix _ _  => true
     | _ => false end.
- 
+
+Hint Rewrite Bool.andb_true_iff: bools.
+Hint Rewrite Bool.andb_false_iff: bools.
+Hint Rewrite Bool.orb_true_iff: bools.
+Hint Rewrite Bool.orb_false_iff: bools.
+Hint Rewrite Bool.negb_true_iff: bools.
+Hint Rewrite Bool.negb_false_iff: bools.
+
+Ltac bools :=
+  autorewrite with bools in *.
+
+Lemma isValueCorrect : forall v, isValue v = true <-> cbv_value v.
+Proof.
+  split.
+  - induction v; repeat step || bools; eauto with values.
+  - induction 1; repeat step || bools.
+Qed.
+
+Definition getPair t : {t': option (tree*tree) | forall t1 t2, t' = Some (t1, t2) <-> t = pp t1 t2}.
+  Proof.
+    exists ( match t with
+    | pp e1 e2 => Some (e1,e2)
+    | _ => None end).
+    destruct t; steps.
+  Qed.
+
+  Definition getApp t : {t': option tree | forall t1, t' = Some t1 <-> t = notype_lambda t1}.
+  Proof.
+    exists (match t with
+       | notype_lambda body => Some body
+       | _ => None end).
+    destruct t; steps.
+Qed.  
+
+  Definition getLR t : {t': option tree | forall t1, t' = Some t1 <-> (t = tleft t1 \/ t = tright t1)}.
+  Proof.
+    exists (match t with
+       | tleft t' => Some t'
+       | tright t' => Some t'
+       | _ => None end).
+    destruct t; steps.
+Qed.      
+
+(* Idea: erase at top level *)
 Fixpoint ss_eval (t: tree) {struct t}: (option tree) :=
   match t with
     | ite ttrue t1 t2 => Some t1
@@ -40,56 +82,237 @@ Fixpoint ss_eval (t: tree) {struct t}: (option tree) :=
                    | true => option_map (pp e1) (ss_eval e2)
                    | false => option_map (fun e => pp e e2) (ss_eval e1) end
 
-    | pi1 (pp e1 _ ) => Some e1
-    | pi1 t => option_map pi1 (ss_eval t)
-    | pi2 (pp _ e2) => Some e2
-    | pi2 t => option_map pi2 (ss_eval t)
+    | pi1 t => match getPair t with
+              | exist _ None _  => option_map pi1 (ss_eval t)
+              | exist _ (Some (e1, e2)) _ => if (isValue e1) && (isValue e2) then Some e1 else option_map pi1 (ss_eval t) end
 
-    | lambda x t_body => Some (notype_lambda t_body) (* remove type annotation *)
-    | app (notype_lambda t_body) t2 => match (isValue t2) with
-                                  | true => Some (open 0 t_body t2)
-                                  | false => option_map (app (notype_lambda t_body)) (ss_eval t2) end
-    | app t1 t2 => match (isValue t2) with
-                    | false => option_map (app t1) (ss_eval t2)
-                    | true => option_map (fun e => app e t2) (ss_eval t1) end
-
-    | notype_tfix t_body => Some (open 0 t_body (notype_tfix t_body))
-
-    | notype_tlet t1 t_body => match isValue t1 with
-                               | true => Some (open 0 t_body t1)
-                               | false => option_map (fun e => notype_tlet e t_body) (ss_eval t1) end
+    | pi2 t => match getPair t with
+              | exist _ None _ => option_map pi2 (ss_eval t)
+              | exist _ (Some (e1, e2)) _ => if (isValue e1) && (isValue e2) then Some e2 else option_map pi2 (ss_eval t) end
+                                                                                                       
+    | app t1 t2 => match (isValue t1) with
+                    | true => match getApp t1 with
+                             | exist _ None _ => option_map (app t1) (ss_eval t2) 
+                             | exist _ (Some ts) _ => if (isValue t2) then Some (open 0 ts t2)
+                                                     else option_map (app t1) (ss_eval t2) end
+                    | false => option_map (fun e => app e t2) (ss_eval t1) end
+                    
+    | notype_tfix ts => Some (open 0 (open 1 ts zero) (notype_tfix ts))
 
     | succ t => option_map succ (ss_eval t)
-    | tmatch zero t0 _ => Some t0
-    | tmatch (succ ts) t0 t1 => match (isNat ts) with
-                                | true => Some (open 0 t1 ts)
-                                | false => option_map (fun e => tmatch (succ e) t0 t1) (ss_eval ts) end
-    | tmatch ts t0 t1 => match (isValue ts) with
-                          | true => None
-                          | false => option_map (fun e => tmatch e t0 t1) (ss_eval ts) end
+                          
+    | tmatch t1 t0 ts => match t1 with
+                       | zero => Some t0
+                       | succ t2 => if (isValue t2) then Some (open 0 ts t2) else option_map (fun e => tmatch e t0 ts) (ss_eval t1)
+                       | _ => option_map (fun e => tmatch e t0 ts) (ss_eval t1) end
 
+    | sum_match t tl tr => if (isValue t) then match t with
+                                   | tleft v => Some (open 0 tl v)
+                                   | tright v => Some (open 0 tr v)
+                                   | _ => None end
+                          else option_map (fun e => sum_match e tl tr) (ss_eval t)
+                            
+                          
+                                           (*
     | sum_match (tleft v) tl tr => match (isValue v) with
                                     | true => Some (open 0 tl v)
                                     | false => option_map (fun e => sum_match (tleft e) tl tr) (ss_eval v) end
     | sum_match (tright v) tl tr => match (isValue v) with
                                     | true => Some (open 0 tr v)
                                     | false => option_map (fun e => sum_match (tright e) tl tr) (ss_eval v) end
-
+*)
     | tleft t => option_map tleft (ss_eval t)
     | tright t => option_map tright (ss_eval t)
 
-    | tsize t => Some (build_nat (tsize_semantics t))
+    | tsize t => if (isValue t) then Some (build_nat (tsize_semantics t)) else (option_map tsize (ss_eval t))
+    | boolean_recognizer r t => if (isValue t) then match r with
+                                                   | 0 => Some (is_pair t)
+                                                   | 1 => Some (is_succ t)
+                                                   | 2 => Some (is_lambda t)
+                                                   | _ => None end
+                               else option_map (boolean_recognizer r) (ss_eval t)
     | _ => None
   end.
+
+
+    
+
+
+Ltac options :=
+unfold option_map in *.
+
+Ltac invert_constructor_equalities :=
+match goal with
+| H: ?F _ = ?F _ |- _ => is_constructor F; inversion H; clear H
+| H: ?F _ _ = ?F _ _ |- _ => is_constructor F; inversion H; clear H
+| H: ?F _ _ _ = ?F _ _ _ |- _ => is_constructor F; inversion H; clear H
+| H: ?F _ _ _ _ = ?F _ _ _ _ |- _ => is_constructor F; inversion H; clear H
+| H: ?F _ _ _ _ _ = ?F _ _ _ _ _ |- _ => is_constructor F; inversion H; clear H
+| H: ?F _ _ _ _ _ _ = ?F _ _ _ _ _ _ |- _ => is_constructor F; inversion H; clear H
+end. 
+
+Ltac custom_light :=
+  (intros) ||
+  (subst).
+
+Ltac destruct_match :=
+match goal with
+| [ |- context[match ?t with _ => _ end]] =>
+let matched := fresh "matched" in
+destruct t eqn:matched
+| [ H: context[match ?t with _ => _ end] |- _ ] =>
+let matched := fresh "matched" in
+destruct t eqn:matched
+end. 
+
+Lemma matchApp : forall T t b1 (b2: T) ,
+   ( exists t_body, t = notype_lambda t_body /\ 
+    match t with
+      | notype_lambda t_body => b1 t_body
+      | _ => b2 end = b1 t_body ) \/
+   ( match t with
+      | notype_lambda t_body => b1 t_body
+      | _ => b2 end = b2 ).
+  Proof.
+  destruct t; repeat steps; eauto.
+Qed.
+
+Ltac destruct_exists :=
+match goal with
+| H: exists x, _ |- _ => let freshX := fresh x in
+                  let matched := fresh "matched_exists" in
+                  destruct H as [ freshX ] eqn:matched
+end.
+
+Ltac instantiate_eq_refl :=
+match goal with
+| H: _ |- _ => pose proof (proj1 (H _) eq_refl); clear H
+| H: _ |- _ => pose proof (proj2 (H _) eq_refl); clear H
+| H: _ |- _ => pose proof (H _ eq_refl); clear H
+| H: _ |- _ => pose proof (H _ _ eq_refl ); clear H
+| H: _ |- _ => pose proof (proj1 (H _ _ ) eq_refl); clear H
+| H: _ |- _ => pose proof (proj2 (H _ _ ) eq_refl); clear H
+| H: _ |- _ => pose proof (H _ _ _ eq_refl); clear H
+| H: _ |- _ => pose proof (H _ _ _ _ eq_refl); clear H
+| H: _ |- _ => pose proof (H _ _ _ _ _ eq_refl); clear H
+| H: _ |- _ => pose proof (H _ _ _ _ _ _ eq_refl); clear H
+end.
+                                               
+Ltac destruct_sig :=
+match goal with
+  | H: _ |- context[let _ := getPair ?t in _ ]  => let fresh := fresh "getPair" in destruct (getPair t) (* eqn:fresh *)
+  | H: context[getPair ?t = _ ] |- _ => let fresh := fresh "getPair" in destruct (getPair t) (* eqn:fresh *)
+  | H: context[_ = getPair ?t ] |- _ => let fresh := fresh "getPair" in destruct (getPair t) (* eqn:fresh *)
+  | H: context[getApp ?t = _ ] |- _ => let fresh := fresh "getApp" in destruct (getApp t) (* eqn:fresh *)
+  | H: context[_ = getApp ?t ] |- _ => let fresh := fresh "getApp" in destruct (getApp t) (* eqn:fresh *)
+end. (* match on type of t = sig *)
+
+
+
+
+
+
+Lemma ss_eval_step : forall t t', ss_eval t = Some t' -> isValue t = true -> False.
+Proof.
+  induction t; repeat step || options.
+Qed.
+
+
+
+Lemma ss_eval_correct2: forall t t',(pfv t term_var = nil) -> scbv_step t t' ->  ss_eval t = Some t'.
+  intros.
+  induction H0 ; repeat light || list_utils || bools || options || invert_constructor_equalities || instantiate_eq_refl || rewrite <- isValueCorrect in *.
+  - (* pi1 *)
+     repeat light || options || bools || instantiate_eq_refl || invert_constructor_equalities || rewrite <- isValueCorrect in * || destruct_sig || destruct_match ; eauto with smallstep values.
+  - (* pi2 *)
+    repeat light || options || bools || instantiate_eq_refl || invert_constructor_equalities || rewrite <- isValueCorrect in * || destruct_sig || destruct_match ; eauto with smallstep values.
+  - (* notype_lambda *)
+    repeat light || options || bools || instantiate_eq_refl || invert_constructor_equalities || rewrite <- isValueCorrect in * || destruct_sig || destruct_match ; eauto with smallstep values.
+  - (* ite *)
+     repeat light || options || bools || instantiate_eq_refl || invert_constructor_equalities || rewrite <- isValueCorrect in * || destruct_sig || destruct_match ; eauto with smallstep values.    
+  - (* ite2 *)
+     repeat light || options || bools || instantiate_eq_refl || invert_constructor_equalities || rewrite <- isValueCorrect in * || destruct_sig || destruct_match ; eauto with smallstep values.   
+  - (* tfix *)
+     repeat light || options || bools || instantiate_eq_refl || invert_constructor_equalities || rewrite <- isValueCorrect in * || destruct_sig || destruct_match ; eauto with smallstep values.     
+  - (* tmatch *)
+    repeat light || options || bools || instantiate_eq_refl || invert_constructor_equalities || rewrite <- isValueCorrect in * || destruct_sig || destruct_match ; eauto with smallstep values.
+  - (* notype_lambda *)
+    repeat light || options || bools || instantiate_eq_refl || invert_constructor_equalities || rewrite <- isValueCorrect in * || destruct_sig || destruct_match ; eauto with smallstep values.
+  - repeat light || options || bools || instantiate_eq_refl || invert_constructor_equalities || rewrite <- isValueCorrect in * || destruct_sig || destruct_match ; eauto with smallstep values.
+  - repeat light || options || bools || instantiate_eq_refl || invert_constructor_equalities || rewrite <- isValueCorrect in * || destruct_sig || destruct_match ; eauto with smallstep values.
+    -     pose proof (ss_eval_step _ _ H). destruct (isValue t1). congruence. rewrite H. reflexivity.
+  - (* sum_match2 *)
+    pose proof (ss_eval_step _ _ H). destruct (isValue t1). congruence. rewrite H. rewrite H0. destruct (getApp v) eqn:A . destruct x. reflexivity. reflexivity.
+  - repeat light || options || bools || instantiate_eq_refl || invert_constructor_equalities || rewrite <- isValueCorrect in * || destruct_sig || destruct_match ; eauto using ss_eval_step with smallstep values.
+    pose proof (ss_eval_step _ _ H matched). inversion H3.
+    pose proof (ss_eval_step _ _ H matched). inversion H3.
+- repeat light || options || bools || instantiate_eq_refl || invert_constructor_equalities || rewrite <- isValueCorrect in * || destruct_sig || destruct_match ; eauto with smallstep values.    
+- repeat light || options || bools || list_utils || instantiate_eq_refl || invert_constructor_equalities || rewrite <- isValueCorrect in * || destruct_sig || destruct_match ; eauto with smallstep values.    
+    pose proof (ss_eval_step _ _  matched0 H4). inversion H1.
+-  repeat light || options || bools || instantiate_eq_refl || invert_constructor_equalities || rewrite <- isValueCorrect in * || destruct_sig || destruct_match ; eauto with smallstep values.    
+    pose proof (ss_eval_step _ _  matched0 H3). inversion H1.
+- repeat light || options || bools || instantiate_eq_refl || invert_constructor_equalities || rewrite <- isValueCorrect in * || destruct_sig || destruct_match ; eauto with smallstep values.    
+
+- repeat light || options || bools || instantiate_eq_refl || invert_constructor_equalities || rewrite <- isValueCorrect in * || destruct_sig || destruct_match ; eauto with smallstep values.
+      pose proof (ss_eval_step _ _  matched0 matched). inversion H.
+
+
+- repeat light || options || bools || instantiate_eq_refl || invert_constructor_equalities || rewrite <- isValueCorrect in * || destruct_sig || destruct_match ; eauto with smallstep values.    
+
+- repeat light || options || bools || instantiate_eq_refl || invert_constructor_equalities || rewrite <- isValueCorrect in * || destruct_sig || destruct_match ; eauto with smallstep values.    
+
+- repeat light || options || bools || instantiate_eq_refl || invert_constructor_equalities || rewrite <- isValueCorrect in * || destruct_sig || destruct_match ; eauto with smallstep values.    
+
+- destruct (isValue t1) eqn:V .  pose proof (ss_eval_step _ _   H V). inversion H2.
+  destruct t1 eqn: T ; repeat light || options || list_utils || bools || instantiate_eq_refl || invert_constructor_equalities || rewrite <- isValueCorrect in * || destruct_sig || destruct_match ; eauto with smallstep values.
+      
+- pose proof ss_eval_step. repeat light || options || bools || instantiate_eq_refl || invert_constructor_equalities || rewrite <- isValueCorrect in * || destruct_sig || destruct_match ; eauto using ss_eval_step with smallstep values.    pose proof (H2 t1 t2 H1 matched). inversion H3.
+  
+
+- rewrite H1. destruct (isValue t1) eqn:V .  pose proof (ss_eval_step _ _   H1 V). inversion H2. reflexivity.
+
+
+Qed.
+
+     
+Lemma ss_eval_correct1: forall t t', ss_eval t = Some t' -> (pfv t term_var = nil) -> scbv_step t t'.
+Proof.
+  induction t; intros ; repeat light.
+  - (* size *)
+    repeat light || options || destruct_match || invert_constructor_equalities || rewrite isValueCorrect in * ; eauto using fv_nil_top_level_var with smallstep.
+  - repeat light || invert_constructor_equalities || instantiate_eq_refl || list_utils || destruct_match || options || rewrite isValueCorrect in *; eauto with smallstep values.
+    rewrite (proj1 (i t) eq_refl) ; eauto with smallstep values.
+  - repeat light || invert_constructor_equalities || instantiate_eq_refl || options || bools || list_utils || rewrite isValueCorrect in * || destruct_sig || destruct_match ; eauto with smallstep values.
+  - repeat light || invert_constructor_equalities || instantiate_eq_refl || options || bools || list_utils || rewrite isValueCorrect in * || destruct_sig || destruct_match ; eauto with smallstep values.
+  - repeat light || invert_constructor_equalities || instantiate_eq_refl || options || bools || list_utils || rewrite isValueCorrect in * || destruct_sig || destruct_match ; eauto with smallstep values.
+  - destruct (ss_eval t1) ; repeat light || invert_constructor_equalities || destruct_match || list_utils || options || rewrite isValueCorrect in *; eauto with smallstep values.
+  - destruct (isValue t) eqn:V;  repeat light || invert_constructor_equalities || list_utils || destruct_match || options || rewrite isValueCorrect in * || eauto using isValueCorrect, fv_nil_top_level_var with smallstep values || unfold option_map in H.
+  - (* tleft *) repeat light || invert_constructor_equalities || list_utils || destruct_match || options || rewrite isValueCorrect in *; eauto with smallstep values.
+
+  - (* Tmatch *) destruct (ss_eval t1); repeat light || invert_constructor_equalities || list_utils || options || destruct_match || rewrite isValueCorrect in *; eauto with smallstep values.
+  - (* notype_tfix *) repeat light || invert_constructor_equalities || list_utils || destruct_match || options || rewrite isValueCorrect in *; eauto with smallstep values.
+  - (* tright *) repeat light || invert_constructor_equalities || list_utils || destruct_match || options || rewrite isValueCorrect in *; eauto with smallstep values.
+  - (* tleft *) repeat light || invert_constructor_equalities || list_utils || destruct_match || options || rewrite isValueCorrect in *; eauto with smallstep values.
+  - (* sum_match *) repeat light || invert_constructor_equalities || list_utils || destruct_match || options || rewrite isValueCorrect in *; eauto with smallstep values.
+Qed.  
+
+
+
+    
 
 Fixpoint ss_eval_n (t : tree) (k: nat) : (option tree) :=
   match k with
     | 0 => Some t
     | S k' => match ss_eval t with
                | Some t' => ss_eval_n t' k'
-               | None => None end
+               | None => Some t end
                end.
+Require Extraction.
+Extraction Language Ocaml.
+Set Extraction AccessOpaque.
 
+
+Extraction "evaluator.ml" ss_eval_n.
 
 Definition example1 :=
 [|
@@ -108,9 +331,18 @@ Definition example1 :=
              end)
         end))
     in
-    (fibo (s (s (s (s 1)))))
+    (fibo (s (s (s (s (s (s (s (s (s (s (s (s 1)))))))))))))
  |].
 
+Fixpoint treeToNat (t: tree) :=
+  match t with
+    | zero => 0
+    | succ t' => S (treeToNat t')
+    |_ => 0 end.
+
+Eval compute in option_map treeToNat (ss_eval_n example1 50000).
+Example fibo377 : option_map treeToNat (ss_eval_n example1 50000) = Some 377.
+Proof. reflexivity. Qed.
 Example fibo4 : (ss_eval_n example1 141) =  Some (succ (succ (succ (succ (succ (succ (succ (succ zero)))))))).
 Proof. compute. reflexivity. Qed.
 
@@ -134,7 +366,10 @@ Definition example2 :=
     (fibo (s (s (s (s (s 1))))))
  |].
 
+Check example2.
+
+Eval compute in ss_eval_n example2 254.
 
 Eval compute in ss_eval_n example2 254.
 Example fibo5 : (ss_eval_n example2 254) =  Some (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ zero))))))))))))).
-Proof. compute. reflexivity. Qed.
+Proof. reflexivity. Qed.

--- a/Evaluator.v
+++ b/Evaluator.v
@@ -1,0 +1,28 @@
+Require Export SystemFR.Trees.
+Require Export SystemFR.Syntax.
+Require Export SystemFR.Freshness.
+
+
+Fixpoint isValue (t: tree) : bool :=
+  match t with
+    | lvar _ _ => true
+    | fvar _ _ => true
+    | uu => true
+    | tsize e => (isValue e)
+    | pp e1 e2 => andb (isValue e1) (isValue e2)
+    | _ => false (* Lacks a looooot of terms *) end.
+
+Definition optionApp (t : tree -> tree) (v : option tree) : option tree :=
+  match v with
+    | None => None
+    | Some v' => Some (t v') end.
+
+Fixpoint eval (t: tree): (option tree) :=
+  match t with
+    | pi1 (pp e1 e2) => Some e1
+    | pp e1 e2 => match (isValue e1) with
+                   | true => optionApp (pp e1) (eval e2)
+                   | false => optionApp (fun e => pp e e2) (eval e1) end
+    | _ => None end.
+
+Eval compute in (eval (pi1 (pp uu uu))).

--- a/Evaluator.v
+++ b/Evaluator.v
@@ -19,8 +19,6 @@ Fixpoint isNat (t : tree) : bool :=
 end.
 Fixpoint isValue (t: tree) : bool :=
   match t with
-    (*| lvar _ _ => true
-    | fvar _ _ => true *)
     | uu => true
     | ttrue => true
     | tfalse => true
@@ -31,6 +29,7 @@ Fixpoint isValue (t: tree) : bool :=
     | succ e1 => (isValue e1)
     | notype_lambda _ => true
     | _ => false end.
+
 Definition getPair t : {t': option (tree*tree) | forall t1 t2, t' = Some (t1, t2) <-> t = pp t1 t2}.
   Proof.
     exists ( match t with
@@ -45,7 +44,7 @@ Definition getPair t : {t': option (tree*tree) | forall t1 t2, t' = Some (t1, t2
        | notype_lambda body => Some body
        | _ => None end).
     destruct t; steps.
-  Defined.  
+  Defined.
 
   Definition getLR t : {t': option tree | forall t1, t' = Some t1 <-> (t = tleft t1 \/ t = tright t1)}.
   Proof.
@@ -54,10 +53,10 @@ Definition getPair t : {t': option (tree*tree) | forall t1 t2, t' = Some (t1, t2
        | tright t' => Some t'
        | _ => None end).
     destruct t; steps.
-  Defined.    
+  Defined.
 
 
-(* Evaluator *)
+(* Evaluator (smallstep) *)
 Fixpoint ss_eval (t: tree) {struct t}: (option tree) :=
   match t with
     | ite ttrue t1 t2 => Some t1
@@ -81,20 +80,20 @@ Fixpoint ss_eval (t: tree) {struct t}: (option tree) :=
                 if (isValue e1) && (isValue e2)
                 then Some e2
                 else option_map pi2 (ss_eval t) end
-                                                                                                       
+
     | app t1 t2 => match (isValue t1) with
                     | true => match getApp t1 with
-                             | exist _ None _ => option_map (app t1) (ss_eval t2) 
+                             | exist _ None _ => option_map (app t1) (ss_eval t2)
                              | exist _ (Some ts) _ =>
                                if (isValue t2)
                                then Some (open 0 ts t2)
                                else option_map (app t1) (ss_eval t2) end
                     | false => option_map (fun e => app e t2) (ss_eval t1) end
-                    
+
     | notype_tfix ts => Some (open 0 (open 1 ts zero) (notype_tfix ts))
 
     | succ t => option_map succ (ss_eval t)
-                          
+
     | tmatch t1 t0 ts => match t1 with
                        | zero => Some t0
                        | succ t2 =>
@@ -108,7 +107,7 @@ Fixpoint ss_eval (t: tree) {struct t}: (option tree) :=
                                    | tright v => Some (open 0 tr v)
                                    | _ => None end
                           else option_map (fun e => sum_match e tl tr) (ss_eval t)
-                            
+
     | tleft t => option_map tleft (ss_eval t)
     | tright t => option_map tright (ss_eval t)
 
@@ -122,6 +121,7 @@ Fixpoint ss_eval (t: tree) {struct t}: (option tree) :=
     | _ => None
   end.
 
+(* Compute a certain number of small steps *)
 Fixpoint ss_eval_n (t : tree) (k: nat) : (option tree) :=
   match k with
     | 0 => Some t
@@ -130,63 +130,12 @@ Fixpoint ss_eval_n (t : tree) (k: nat) : (option tree) :=
                | None => Some t end
   end.
 
+(* Entry point for evaluation *)
 Definition eval (t: tree) (k: nat): (option tree) :=
   ss_eval_n (erase_term t) k.
 
 
 (* Tactics *)
-Hint Rewrite Bool.andb_true_iff: bools.
-Hint Rewrite Bool.andb_false_iff: bools.
-Hint Rewrite Bool.orb_true_iff: bools.
-Hint Rewrite Bool.orb_false_iff: bools.
-Hint Rewrite Bool.negb_true_iff: bools.
-Hint Rewrite Bool.negb_false_iff: bools.
-Ltac bools :=
-  autorewrite with bools in *.
-       
-Ltac options :=
-unfold option_map in *.
-
-Ltac invert_constructor_equalities :=
-match goal with
-| H: ?F _ = ?F _ |- _ => is_constructor F; inversion H; clear H
-| H: ?F _ _ = ?F _ _ |- _ => is_constructor F; inversion H; clear H
-| H: ?F _ _ _ = ?F _ _ _ |- _ => is_constructor F; inversion H; clear H
-| H: ?F _ _ _ _ = ?F _ _ _ _ |- _ => is_constructor F; inversion H; clear H
-| H: ?F _ _ _ _ _ = ?F _ _ _ _ _ |- _ => is_constructor F; inversion H; clear H
-| H: ?F _ _ _ _ _ _ = ?F _ _ _ _ _ _ |- _ => is_constructor F; inversion H; clear H
-end. 
-
-Ltac custom_light :=
-  (intros) ||
-  (subst).
-
-Ltac destruct_match :=
-match goal with
-| [ |- context[match ?t with _ => _ end]] =>
-let matched := fresh "matched" in
-destruct t eqn:matched
-| [ H: context[match ?t with _ => _ end] |- _ ] =>
-let matched := fresh "matched" in
-destruct t eqn:matched
-end. 
-
-
-
-Ltac instantiate_eq_refl :=
-match goal with
-| H: _ |- _ => pose proof (proj1 (H _) eq_refl); clear H
-| H: _ |- _ => pose proof (proj2 (H _) eq_refl); clear H
-| H: _ |- _ => pose proof (H _ eq_refl); clear H
-| H: _ |- _ => pose proof (H _ _ eq_refl ); clear H
-| H: _ |- _ => pose proof (proj1 (H _ _ ) eq_refl); clear H
-| H: _ |- _ => pose proof (proj2 (H _ _ ) eq_refl); clear H
-| H: _ |- _ => pose proof (H _ _ _ eq_refl); clear H
-| H: _ |- _ => pose proof (H _ _ _ _ eq_refl); clear H
-| H: _ |- _ => pose proof (H _ _ _ _ _ eq_refl); clear H
-| H: _ |- _ => pose proof (H _ _ _ _ _ _ eq_refl); clear H
-end.
-                                               
 Ltac destruct_sig :=
 match goal with
   | H: _ |- context[let _ := getPair ?t in _ ]  => let fresh := fresh "getPair" in destruct (getPair t) (* eqn:fresh *)
@@ -195,6 +144,7 @@ match goal with
   | H: context[getApp ?t = _ ] |- _ => let fresh := fresh "getApp" in destruct (getApp t) (* eqn:fresh *)
   | H: context[_ = getApp ?t ] |- _ => let fresh := fresh "getApp" in destruct (getApp t) (* eqn:fresh *)
 end. (* match on type of t = sig *)
+
 Ltac destruct_ss_eval :=
   match goal with
     | H: context[ss_eval ?t] |- _ => destruct (ss_eval t) end.
@@ -219,14 +169,18 @@ Ltac ss_eval_step :=
 
 
 Lemma ss_eval_correct2: forall t t',(pfv t term_var = nil) -> scbv_step t t' ->  ss_eval t = Some t'.
-  intros.
-  induction H0 ;
-    repeat light || options || invert_constructor_equalities || ss_eval_step || destruct_sig || instantiate_eq_refl || list_utils || bools || rewrite <- isValueCorrect in * ||  eauto using fv_nil_top_level_var with smallstep values || destruct_match.
+  intros. induction H0 ; repeat light || options || invert_constructor_equalities || ss_eval_step || destruct_sig || instantiate_eq_refl || list_utils || bools || rewrite <- isValueCorrect in * ||  eauto using fv_nil_top_level_var with smallstep values || destruct_match.
 Qed.
 
 Lemma ss_eval_correct1: forall t t', ss_eval t = Some t' -> (pfv t term_var = nil) -> scbv_step t t'.
 Proof.
   induction t; intros ; repeat light ; destruct_ss_eval ; repeat light || options || bools || list_utils || instantiate_eq_refl || invert_constructor_equalities || rewrite isValueCorrect in * || destruct_sig || congruence ||  step_inversion cbv_value || destruct_match ; eauto using ss_eval_step, fv_nil_top_level_var with smallstep values . Qed.
+
+(* Main theorem : the evaluator corresponds to the small call-by-value steps *)
+Theorem ss_eval_correct : forall t t', (pfv t term_var = nil) -> (ss_eval t = Some t' <-> scbv_step t t').
+Proof.
+  intros. split ; eauto using ss_eval_correct1, ss_eval_correct2.
+Qed.
 
 
 (* Extraction *)
@@ -236,5 +190,4 @@ Extraction Language Ocaml.
 Set Extraction AccessOpaque.
 
 
-Extraction "evaluator.ml" eval. 
-    
+Extraction "evaluator.ml" eval.

--- a/Evaluator.v
+++ b/Evaluator.v
@@ -1,8 +1,7 @@
 Require Export SystemFR.Trees.
 Require Export SystemFR.Syntax.
 Require Export SystemFR.Freshness.
-(* Require Import SystemFR.Notations. *)
-
+Require Import SystemFR.Notations.
 
 Fixpoint isValue (t: tree) : bool :=
   match t with
@@ -12,21 +11,64 @@ Fixpoint isValue (t: tree) : bool :=
     | ttrue => true
     | tfalse => true
     | pp e1 e2 => andb (isValue e1) (isValue e2)
+    | tleft e1 => (isValue e1)
+    | tright e1 => (isValue e1)
+    | zero => true
+    | succ e1 => (isValue e1)
     | _ => false (* Lacks a looooot of terms *) end.
 
-Fixpoint ss_eval (t: tree): (option tree) :=
+Fixpoint isNat (t : tree) : bool :=
   match t with
-    | pi1 (pp e1 e2) => match (isValue e1, isValue e2) with
-                         | (true, true) => Some e1
-                         | (true, false) => option_map (fun e => pi1 (pp e1 e)) (ss_eval e2)
-                         | (false, _) => option_map (fun e => pi1 (pp e e2)) (ss_eval e1)
-                       end
+    | zero => true
+    | succ t1 => (isNat t1)
+    | _ => false
+end.
+ 
+Fixpoint ss_eval (t: tree) {struct t}: (option tree) :=
+  match t with
+    | ite ttrue t1 t2 => Some t1
+    | ite tfalse t1 t2 => Some t2
+    | ite t t1 t2 => option_map (fun e => ite e t1 t2) (ss_eval t)
+
     | pp e1 e2 => match (isValue e1) with
                    | true => option_map (pp e1) (ss_eval e2)
                    | false => option_map (fun e => pp e e2) (ss_eval e1) end
+
+    | pi1 (pp e1 _ ) => Some e1
+    | pi1 t => option_map pi1 (ss_eval t)
+    | pi2 (pp _ e2) => Some e2
+    | pi2 t => option_map pi2 (ss_eval t)
+
+    | app (lambda x t_body) t2 => match (isValue t2) with
+                                  | true => Some (open 0 t_body t2)
+                                  | false => option_map (app (lambda x t_body)) (ss_eval t2) end
+    | app t1 t2 => match (isValue t1) with
+                    | true => option_map (app t1) (ss_eval t2)
+                    | false => option_map (fun e => app e t2) (ss_eval t1) end
+    (* Fix ? *)
+                    
+    | tmatch zero t0 _ => Some t0
+    | tmatch (succ ts) t0 t1 => match (isValue ts) with
+                                | true => match (isNat ts) with
+                                           | true => Some (open 0 t1 ts)
+                                           | false => None end
+                                | false => option_map (fun e => tmatch (succ e) t0 t1) (ss_eval ts) end
+
+    | sum_match (tleft v) tl tr => match (isValue v) with
+                                    | true => Some (open 0 tl v)
+                                    | false => option_map (fun e => sum_match (tleft e) tl tr) (ss_eval v) end
+    | sum_match (tright v) tl tr => match (isValue v) with
+                                    | true => Some (open 0 tr v)
+                                    | false => option_map (fun e => sum_match (tright e) tl tr) (ss_eval v) end
+
+    | tleft t => option_map tleft (ss_eval t)
+    | tright t => option_map tright (ss_eval t)
+                           
     | _ => None end.
 
-Eval compute in (ss_eval (pp (pi1 (pp ttrue uu)) uu)).
-Eval compute in (ss_eval (pi1 (pp ttrue uu))).
+
+Fixpoint bs_eval (t: tree): (option tree) :=
+  match t with
+    | _ => None end.
 
 Search (_ -> option _).

--- a/Notations.v
+++ b/Notations.v
@@ -13,9 +13,9 @@ Notation "'⤳' t" := (fun (fv_id:nat) => t) (at level 100).
 Notation "[| x |]" := (x 0) (x custom expr).
 Notation "[|| x ||]" := (x 0) (x custom type).
 Notation "( x )" := (fun (fv_id:nat) => (x fv_id)) (in custom expr, x custom expr).
-Notation "x" := (fun fv_id => x) (in custom expr at level 0, x ident). 
+Notation "x" := (⤳ x) (in custom expr at level 0, x ident). 
 Notation "( x )" := (fun (fv_id:nat) => (x fv_id)) (in custom type, x custom type).
-Notation "x" := (fun fv_id => x) (in custom type at level 0, x ident). 
+Notation "x" := (⤳ x) (in custom type at level 0, x ident). 
 
 (* Variables (nameless) *)
 Notation "'ft{' v '}'" := (⤳ (fvar v term_var)) (in custom expr, v constr).
@@ -210,7 +210,7 @@ Notation "'def_rec' f x y => t":=
 
 Notation " t1 t2 " :=
   (fun fv_id => (app (t1 fv_id) (t2 fv_id)))
-    (in custom expr at level 200, right associativity,
+    (in custom expr at level 200, left associativity,
         t1 custom expr,
         t2 custom expr).
 

--- a/Notations.v
+++ b/Notations.v
@@ -10,12 +10,13 @@ Open Scope list.
 (* Untyped embedded language *)
 Module UnTyped.
   Declare Custom Entry expr.
-  
+
   (* Entry point *)
   Notation "'⤳' t" := (fun (fv_id:nat) => t) (at level 100).
   Notation "[| x |]" := (x 0) (x custom expr).
   Notation "( x )" := (fun (fv_id:nat) => (x fv_id)) (in custom expr, x custom expr).
-  Notation "x" := (⤳ x) (in custom expr at level 0, x ident). 
+  Notation "x" := (⤳ x) (in custom expr at level 0, x ident).
+
   (* Variables (nameless) - not used in practice *)
   Notation "'ft{' v '}'" := (⤳ (fvar v term_var)) (in custom expr, v constr).
   Notation "'lt{' v '}'" := (⤳ (lvar v term_var)) (in custom expr, v constr).
@@ -33,7 +34,7 @@ Module UnTyped.
   Notation "'7'" := (⤳ (succ (succ (succ (succ (succ (succ (succ zero)))))))) (in custom expr).
   Notation "'8'" := (⤳ (succ (succ (succ (succ (succ (succ (succ (succ zero))))))))) (in custom expr).
   Notation "'9'" := (⤳ (succ (succ (succ (succ (succ (succ (succ (succ (succ zero)))))))))) (in custom expr).
-  
+
   Notation "'()'" := (⤳ uu) (in custom expr).
   Notation "'t_true'" := (⤳ttrue) (in custom expr).
   Notation "'t_false'" := (⤳tfalse) (in custom expr).
@@ -49,8 +50,8 @@ Module UnTyped.
   Notation "( t1 , t2 )" :=
     (fun (fv_id:nat) => (pp (t1 fv_id) (t2 fv_id)))
       (in custom expr, t1 custom expr, t2 custom expr).
-  Notation "t '._1'" := (fun fv_id => (pi1 (t fv_id))) (in custom expr at level 200, t custom expr).
-  Notation "t '._2'" := (fun fv_id => (pi2 (t fv_id))) (in custom expr at level 200, t custom expr).
+  Notation "t '._1'" := (fun fv_id => (pi1 (t fv_id))) (in custom expr at level 80, t custom expr).
+  Notation "t '._2'" := (fun fv_id => (pi2 (t fv_id))) (in custom expr at level 80, t custom expr).
 
   (* Needs Coq 8.11 to work
 Definition pp_notation (p1 : nat -> tree) (p2 : nat -> tree) : (nat -> tree) :=
@@ -71,7 +72,7 @@ Notation "( t1 , .. , t2 , tn )" :=
          let x := (fvar (S fv_id) term_var) in
          (notype_tfix (close 0 (notype_lambda (close 0 (t (S (S fv_id))) (S fv_id))) fv_id) )))
       (in custom expr at level 100, f ident, x ident, t custom expr).
-  Notation "'def_rec' f x y => t":=
+  Notation "'def_rec' f x y => t":= (* for convinience, recursive with 2 arguments *)
     (fun fv_id => (
          let f := (fvar fv_id term_var) in
          let x := (fvar (S fv_id) term_var) in
@@ -107,7 +108,7 @@ Notation "( t1 , .. , t2 , tn )" :=
   Notation "'right' t " :=
     (fun fv_id => tright (t fv_id))
       (in custom expr at level 180, right associativity, t custom expr).
-  Notation "'left' t " := 
+  Notation "'left' t " :=
     (fun fv_id => tleft (t fv_id))
       (in custom expr at level 180, right associativity, t custom expr).
   Notation "'match' t 'with' '|' 'left' l => t1 '|' 'right' r => t2 'end'" :=
@@ -129,7 +130,7 @@ Module Typed.
   Notation "( x )" := (fun (fv_id:nat) => (x fv_id)) (in custom type, x custom type).
   Notation "x" := (⤳ x) (in custom type at level 0, x ident).
 
-  (* Base Types *) 
+  (* Base Types *)
   Notation "'Nat'" := (⤳ T_nat) (in custom type).
   Notation "'Unit'" := (⤳ T_unit) (in custom type).
   Notation "'Bool'" := (⤳ T_bool) (in custom type).
@@ -206,7 +207,7 @@ End Typed.
 
 Module Tests.
   Import UnTyped.
-  Import Typed.  
+  Import Typed.
   Example base_types : ([|| Nat ||], [|| Unit ||], [|| Bool ||], [|| ⊤ ||], [|| ⊥ ||]) = (T_nat, T_unit, T_bool, T_top, T_bot). Proof. reflexivity. Qed.
   Example arrow_type1 : [|| (Nat -> Bool) -> Unit -> ⊤ ||] = T_arrow (T_arrow T_nat T_bool) (T_arrow T_unit T_top).
   Proof. reflexivity. Qed.
@@ -227,8 +228,4 @@ Module Tests.
   Example union_type1 : [|| Nat ∩ Bool ∪ Nat ||] = T_union (T_intersection T_nat T_bool) T_nat.
   Proof. reflexivity. Qed.
 
-End Tests.    
-
-
-
-
+End Tests.

--- a/Notations.v
+++ b/Notations.v
@@ -2,109 +2,185 @@ Require Export SystemFR.Trees.
 Require Export SystemFR.Syntax.
 Require Export SystemFR.Freshness.
 
-
 Open Scope list.
 
-Declare Custom Entry expr.
-Declare Custom Entry type.
-
-(* Entry point *)
-Notation "'⤳' t" := (fun (fv_id:nat) => t) (at level 100).
-Notation "[| x |]" := (x 0) (x custom expr).
-Notation "[|| x ||]" := (x 0) (x custom type).
-Notation "( x )" := (fun (fv_id:nat) => (x fv_id)) (in custom expr, x custom expr).
-Notation "x" := (⤳ x) (in custom expr at level 0, x ident). 
-Notation "( x )" := (fun (fv_id:nat) => (x fv_id)) (in custom type, x custom type).
-Notation "x" := (⤳ x) (in custom type at level 0, x ident). 
-
-(* Variables (nameless) *)
-Notation "'ft{' v '}'" := (⤳ (fvar v term_var)) (in custom expr, v constr).
-Notation "'lt{' v '}'" := (⤳ (lvar v term_var)) (in custom expr, v constr).
-Notation "'fT{' v '}'" := (⤳ (fvar v type_var)) (in custom expr, v constr).
-Notation "'lT{' v '}'" := (⤳ (lvar v type_var)) (in custom expr, v constr).
 
 
-(* Types *) (* constr and custom entries share the same lexer --' ) (WTF?)*)
-Notation "'Nat'" := (⤳ T_nat) (in custom type).
-Notation "'Unit'" := (⤳ T_unit) (in custom type).
-Notation "'Bool'" := (⤳ T_bool) (in custom type).
-Notation "'⊤'" := (⤳ T_top) (in custom type).
-Notation "'⊥'" := (⤳ T_bot) (in custom type).
 
-Example base_types : ([|| Nat ||], [|| Unit ||], [|| Bool ||], [|| ⊤ ||], [|| ⊥ ||]) = (T_nat, T_unit, T_bool, T_top, T_bot). Proof. reflexivity. Qed.
+(* Untyped embedded language *)
+Module UnTyped.
+  Declare Custom Entry expr.
+  
+  (* Entry point *)
+  Notation "'⤳' t" := (fun (fv_id:nat) => t) (at level 100).
+  Notation "[| x |]" := (x 0) (x custom expr).
+  Notation "( x )" := (fun (fv_id:nat) => (x fv_id)) (in custom expr, x custom expr).
+  Notation "x" := (⤳ x) (in custom expr at level 0, x ident). 
+  (* Variables (nameless) - not used in practice *)
+  Notation "'ft{' v '}'" := (⤳ (fvar v term_var)) (in custom expr, v constr).
+  Notation "'lt{' v '}'" := (⤳ (lvar v term_var)) (in custom expr, v constr).
+  Notation "'fT{' v '}'" := (⤳ (fvar v type_var)) (in custom expr, v constr).
+  Notation "'lT{' v '}'" := (⤳ (lvar v type_var)) (in custom expr, v constr).
 
-Notation "[ t1 ≡ t2 ]" :=
-  (fun fv_id => (T_equiv (t1 fv_id) (t2 fv_id)))
-    (in custom type at level 200,
-     t1 custom expr,
-     t2 custom expr).
+  (* Base terms *)
+  Notation "'0'" := (⤳ zero) (in custom expr).
+  Notation "'1'" := (⤳ (succ zero)) (in custom expr).
+  Notation "'()'" := (⤳ uu) (in custom expr).
+  Notation "'t_true'" := (⤳ttrue) (in custom expr).
+  Notation "'t_false'" := (⤳tfalse) (in custom expr).
+  Notation "'error'" := (notype_err) (in custom expr).
+  Notation "'size' t " := (fun fv_id => (tsize (t fv_id))) (in custom expr at level 0,
+                                                            t custom expr).
+  (* Conditionnal *)
+  Notation "'if' c 'then' t 'else' f" :=
+    (fun fv_id => (ite (c fv_id) (t fv_id) (f fv_id)))
+      (in custom expr at level 1, c custom expr, t custom expr, f custom expr).
 
-Notation "τ1 -> τ2" := (fun fv_id => (T_arrow (τ1 fv_id) (τ2 fv_id))) (in custom type at level 90, right associativity, τ1 custom type, τ2 custom type).
-Notation "x : τ1 -> τ2" :=
-  (fun fv_id => (
-       let x := (fvar fv_id term_var) in
-       (T_arrow (τ1 fv_id) (close 0 (τ2 (S fv_id)) fv_id ))))
-    (in custom type, τ1 custom type at level 85, τ2 custom type at next level, x ident).
+  (* Pairs *)
+  Notation "( t1 , t2 )" :=
+    (fun (fv_id:nat) => (pp (t1 fv_id) (t2 fv_id)))
+      (in custom expr, t1 custom expr, t2 custom expr).
+  Notation "t '._1'" := (fun fv_id => (pi1 (t fv_id))) (in custom expr at level 200, t custom expr).
+  Notation "t '._2'" := (fun fv_id => (pi2 (t fv_id))) (in custom expr at level 200, t custom expr).
 
-Example arrow_type1 : [|| (Nat -> Bool) -> Unit -> ⊤ ||] = T_arrow (T_arrow T_nat T_bool) (T_arrow T_unit T_top).
-Proof. reflexivity. Qed.
-Example arrow_type2 : [|| x : Nat -> y : Nat -> [x ≡ y] ||] = T_arrow T_nat (T_arrow T_nat (T_equiv (lvar 1 term_var) (lvar 0 term_var))).
-Proof. reflexivity. Qed.
+  (* Needs Coq 8.11 to work
+Definition pp_notation (p1 : nat -> tree) (p2 : nat -> tree) : (nat -> tree) :=
+  fun (fv_id : nat) => pp (p1 fv_id) (p2 fv_id).
+Notation "( t1 , .. , t2 , tn )" :=
+  (pp_notation  t1 .. (pp_notation t2 tn) ..)
+    (in custom expr, t1  custom expr, t2 custom expr, tn custom expr, left associativity). *)
+
+  (* Functions *)
+  Notation "'fun' x  => t" := (* non-recursive *)
+    (fun fv_id => (
+         let x := (fvar fv_id term_var) in
+         (notype_lambda (close 0 (t (S fv_id)) fv_id))))
+      (in custom expr at level 100, x ident, t custom expr).
+  Notation "'def_rec' f x => t":= (* recursive *)
+    (fun fv_id => (
+         let f := (fvar fv_id term_var) in
+         let x := (fvar (S fv_id) term_var) in
+         (notype_tfix (close 0 (notype_lambda (close 0 (t (S (S fv_id))) (S fv_id))) fv_id) )))
+      (in custom expr at level 100, f ident, x ident, t custom expr).
+  Notation "'def_rec' f x y => t":=
+    (fun fv_id => (
+         let f := (fvar fv_id term_var) in
+         let x := (fvar (S fv_id) term_var) in
+         let y := (fvar (S (S fv_id)) term_var) in
+         (notype_tfix (close 0 (
+                               notype_lambda (close 0 (notype_lambda (
+                                                           close 0 (t (S(S(S fv_id))))
+                                                                 (S (S fv_id)))) (S fv_id))) fv_id))))
+      (in custom expr at level 100, f ident, x ident, y ident, t custom expr).
+  Notation " t1 t2 " :=
+    (fun fv_id => (app (t1 fv_id) (t2 fv_id)))
+      (in custom expr at level 50, right associativity,
+          t1 custom expr,
+          t2 custom expr).
+
+  (* Naturals *)
+  Notation "'s' t" := (fun fv_id => (succ (t fv_id))) (in custom expr at level 2, t custom expr).
+  Notation "'match' t 'with' '|' '0' => t1 '|' 's' x => t2 'end'" :=
+    (fun (fv_id:nat) => (
+         tmatch (t fv_id)
+                (t1 fv_id)
+                (let x := (fvar fv_id term_var) in (close 0 (t2 (S fv_id)) fv_id))))
+      (in custom expr at level 190, t custom expr, t1 custom expr, t2 custom expr, x ident).
+
+  (* Let expression *)
+  Notation "'let' x := t1 'in' t2" :=
+    (fun (fv_id : nat) => (
+         notype_tlet (t1 fv_id)
+                     (let x := (fvar fv_id term_var) in (close 0 (t2 (S fv_id)) fv_id) )))
+      (in custom expr at level 190, t1 custom expr, t2 custom expr, x ident).
+
+  (* Sum *)
+  Notation "'right' t " :=
+    (fun fv_id => tright (t fv_id))
+      (in custom expr at level 180, right associativity, t custom expr).
+  Notation "'left' t " := 
+    (fun fv_id => tleft (t fv_id))
+      (in custom expr at level 180, right associativity, t custom expr).
+  Notation "'match' t 'with' '|' 'left' l => t1 '|' 'right' r => t2 'end'" :=
+    (fun (fv_id:nat) => (
+         tmatch (t fv_id)
+                (let l  := (fvar fv_id term_var) in (close 0 (t1 (S fv_id)) fv_id))
+                (let r := (fvar fv_id term_var) in (close 0 (t2 (S fv_id)) fv_id))))
+      (in custom expr at level 190, t custom expr, t1 custom expr, t2 custom expr, l ident, r ident).
+
+End UnTyped.
 
 
-Notation "τ1 * τ2" :=(fun fv_id => (T_prod (τ1 fv_id) (τ2 fv_id))) (in custom type at level 90, right associativity, τ1 custom type, τ2 custom type).
+Module Typed.
+  Import UnTyped.
+  Declare Custom Entry type.
 
-Notation "x : τ1 * τ2" :=
-  (fun fv_id => (
-       let x := (fvar fv_id term_var) in
-       (T_prod (τ1 fv_id) (close 0 (τ2 (S fv_id)) fv_id ))))
-    (in custom type, τ1 custom type at level 85, τ2 custom type at level 100, x ident).
+  (* Additionnal entry points *)
+  Notation "[|| x ||]" := (x 0) (x custom type).
+  Notation "( x )" := (fun (fv_id:nat) => (x fv_id)) (in custom type, x custom type).
+  Notation "x" := (⤳ x) (in custom type at level 0, x ident).
 
+  (* Base Types *) 
+  Notation "'Nat'" := (⤳ T_nat) (in custom type).
+  Notation "'Unit'" := (⤳ T_unit) (in custom type).
+  Notation "'Bool'" := (⤳ T_bool) (in custom type).
+  Notation "'⊤'" := (⤳ T_top) (in custom type).
+  Notation "'⊥'" := (⤳ T_bot) (in custom type).
 
-Example prod_type1 : [|| Nat * Bool ||] = T_prod T_nat T_bool.
-Proof. simpl. reflexivity. Qed.
-Example prod_type2 : [|| x : Nat * Bool * Unit ||] = T_prod T_nat (T_prod T_bool T_unit).
-Proof. reflexivity. Qed.
+  (* Additionnal base terms *)
+  Notation "'error' [ T ] " := (fun fv_id => err (T fv_id)) (in custom expr, T custom type).
 
+  (* Equivalence *)
+  Notation "[ t1 ≡ t2 ]" :=
+    (fun fv_id => (T_equiv (t1 fv_id) (t2 fv_id)))
+      (in custom type at level 200,
+          t1 custom expr,
+          t2 custom expr).
 
-Notation "τ1 + τ2" :=
-  (fun fv_id => (T_sum (τ1 fv_id) (τ2 fv_id))) (in custom type at level 95, τ1 custom type, τ2 custom type).
+  (* Arrow type *)
+  Notation "τ1 -> τ2" := (fun fv_id => (T_arrow (τ1 fv_id) (τ2 fv_id))) (in custom type at level 90, right associativity, τ1 custom type, τ2 custom type).
+  Notation "x : τ1 -> τ2" :=
+    (fun fv_id => (
+         let x := (fvar fv_id term_var) in
+         (T_arrow (τ1 fv_id) (close 0 (τ2 (S fv_id)) fv_id ))))
+      (in custom type, τ1 custom type at level 85, τ2 custom type at next level, x ident).
 
-Eval compute in [|| Bool -> Nat + Unit ||].
+  (* Prod type *)
+  Notation "τ1 * τ2" :=(fun fv_id => (T_prod (τ1 fv_id) (τ2 fv_id))) (in custom type at level 90, right associativity, τ1 custom type, τ2 custom type).
+  Notation "x : τ1 * τ2" :=
+    (fun fv_id => (
+         let x := (fvar fv_id term_var) in
+         (T_prod (τ1 fv_id) (close 0 (τ2 (S fv_id)) fv_id ))))
+      (in custom type, τ1 custom type at level 85, τ2 custom type at level 100, x ident).
 
-Example sum_type1 : [|| Bool -> Nat + Unit ||] = T_sum (T_arrow T_bool T_nat) T_unit.
-Proof. reflexivity. Qed.
+  (* Sum type *)
+  Notation "τ1 + τ2" :=
+    (fun fv_id => (T_sum (τ1 fv_id) (τ2 fv_id))) (in custom type at level 95, τ1 custom type, τ2 custom type).
+  Notation "x : τ1 + τ2" :=
+    (fun fv_id => (
+         let x := (fvar fv_id term_var) in
+         (T_sum (τ1 fv_id) (close 0 (τ2 (S fv_id)) fv_id ))))
+      (in custom type, τ1 custom type at level 85, τ2 custom type at level 100, x ident).
 
-Example sum_type2 : [|| Nat + x : Bool -> y : Nat * [x ≡ y] + Nat ||] =  T_sum T_nat (T_arrow T_bool (T_prod T_nat (T_sum (T_equiv (lvar 1 term_var) (lvar 0 term_var)) T_nat))).
-Proof. reflexivity. Qed.
+  (* Refinement types *)
+  Notation "{ x : τ1 | t }" :=
+    (fun fv_id => (
+         let x := (fvar fv_id term_var) in
+         (T_refine (τ1 fv_id) (close 0 (t (S fv_id)) fv_id))))
+      (in custom type at level 200, τ1 custom type, t custom expr, x ident).
+  Notation "{{ x : τ1 | τ2 }}" :=
+    (fun fv_id => (
+         let x := (fvar fv_id term_var) in
+         (T_type_refine (τ1 fv_id) (close 0 (τ2 (S fv_id)) fv_id))))
+      (in custom type at level 200, τ1 custom type, τ2 custom type, x ident).
 
+  (* Union type *)
+  Notation "τ1 ∪ τ2" :=
+    (fun fv_id => (T_union (τ1 fv_id) (τ2 fv_id))) (in custom type at level 190, right associativity, τ1 custom type, τ2 custom type).
 
-Notation "{ x : τ1 | t }" :=
-  (fun fv_id => (
-       let x := (fvar fv_id term_var) in
-       (T_refine (τ1 fv_id) (close 0 (t (S fv_id)) fv_id))))
-    (in custom type at level 200, τ1 custom type, t custom expr, x ident).
-
-Example refine_type1 : [|| { x : Bool | x } ||] = T_refine T_bool (lvar 0 term_var).
-Proof. reflexivity. Qed.
-
-Notation "{{ x : τ1 | τ2 }}" :=
-  (fun fv_id => (
-       let x := (fvar fv_id term_var) in
-       (T_type_refine (τ1 fv_id) (close 0 (τ2 (S fv_id)) fv_id))))
-    (in custom type at level 200, τ1 custom type, τ2 custom type, x ident).
-
-Example refine_by_type1 : [|| {{ x : Bool | [x ≡ x] }} ||] = (T_type_refine T_bool (T_equiv (lvar 0 term_var) (lvar 0 term_var))).
-Proof. reflexivity. Qed.
-
-Notation "τ1 ∪ τ2" :=
-  (fun fv_id => (T_union (τ1 fv_id) (τ2 fv_id))) (in custom type at level 190, right associativity, τ1 custom type, τ2 custom type).
-Notation "τ1 ∩ τ2" :=
-  (fun fv_id => (T_intersection (τ1 fv_id) (τ2 fv_id))) (in custom type at level 170, right associativity, τ1 custom type, τ2 custom type).
-
-Example union_type1 : [|| Nat ∩ Bool ∪ Nat ||] = T_union (T_intersection T_nat T_bool) T_nat.
-Proof. reflexivity. Qed.
-
+  (* Intersection type *)
+  Notation "τ1 ∩ τ2" :=
+    (fun fv_id => (T_intersection (τ1 fv_id) (τ2 fv_id))) (in custom type at level 170, right associativity, τ1 custom type, τ2 custom type).
 (*
 Notation "'forall' x : τ1 . τ2" :=
   (fun fv_id => (
@@ -115,235 +191,34 @@ Notation "'forall' α : 'Type' . τ1 ":=
   (fun fv_id => (
        let α := (fvar fv_id type_var) in
        (T_abs (tclose 0 (τ1 (S fv_id)) fv_id))))
-    (in custom type at level 190, right associativity, τ1 custom type, α ident).
+    (in custom type at level 190, right associativity, τ1 custom type, α ident). *)
 
-(* Tests *)
-Eval compute in
-    [|| Nat ||].
-Eval compute in
-[||  Nat ∩ Bool ∪ Unit ∪ (forall x : Type . Nat) ||]. *)
-                   
+End Typed.
 
+Module Tests.
+  Import UnTyped.
+  Import Typed.  
+  Example base_types : ([|| Nat ||], [|| Unit ||], [|| Bool ||], [|| ⊤ ||], [|| ⊥ ||]) = (T_nat, T_unit, T_bool, T_top, T_bot). Proof. reflexivity. Qed.
+  Example arrow_type1 : [|| (Nat -> Bool) -> Unit -> ⊤ ||] = T_arrow (T_arrow T_nat T_bool) (T_arrow T_unit T_top).
+  Proof. reflexivity. Qed.
+  Example arrow_type2 : [|| x : Nat -> y : Nat -> [x ≡ y] ||] = T_arrow T_nat (T_arrow T_nat (T_equiv (lvar 1 term_var) (lvar 0 term_var))).
+  Proof. reflexivity. Qed.
+  Example prod_type1 : [|| Nat * Bool ||] = T_prod T_nat T_bool.
+  Proof. simpl. reflexivity. Qed.
+  Example prod_type2 : [|| x : Nat * Bool * Unit ||] = T_prod T_nat (T_prod T_bool T_unit).
+  Proof. reflexivity. Qed.
+  Example sum_type1 : [|| Bool -> Nat + Unit ||] = T_sum (T_arrow T_bool T_nat) T_unit.
+  Proof. reflexivity. Qed.
+  Example sum_type2 : [|| Nat + x : Bool -> y : Nat * [x ≡ y] + Nat ||] =  T_sum T_nat (T_arrow T_bool (T_prod T_nat (T_sum (T_equiv (lvar 1 term_var) (lvar 0 term_var)) T_nat))).
+  Proof. reflexivity. Qed.
+  Example refine_type1 : [|| { x : Bool | x } ||] = T_refine T_bool (lvar 0 term_var).
+  Proof. reflexivity. Qed.
+  Example refine_by_type1 : [|| {{ x : Bool | [x ≡ x] }} ||] = (T_type_refine T_bool (T_equiv (lvar 0 term_var) (lvar 0 term_var))).
+  Proof. reflexivity. Qed.
+  Example union_type1 : [|| Nat ∩ Bool ∪ Nat ||] = T_union (T_intersection T_nat T_bool) T_nat.
+  Proof. reflexivity. Qed.
 
-(* Terms *)
-
-(* Base terms *)
-Notation "'0'" := (⤳ zero) (in custom expr).
-Notation "'()'" := (⤳ uu) (in custom expr).
-
-Notation "'error'" := (notype_err) (in custom expr).
-Notation "'error' [ T ] " := (fun fv_id => err (T fv_id)) (in custom expr, T custom type).
-
-(* Pairs *)
-Notation "( t1 , t2 )" :=
-  (fun (fv_id:nat) => (pp (t1 fv_id) (t2 fv_id)))
-  (in custom expr, t1 custom expr, t2 custom expr).
-
-(*
-Needs Coq 8.11 to work
-Definition pp_notation (p1 : nat -> tree) (p2 : nat -> tree) : (nat -> tree) :=
-  fun (fv_id : nat) => pp (p1 fv_id) (p2 fv_id).
-
-Notation "( t1 , .. , t2 , tn )" :=
-  (pp_notation  t1 .. (pp_notation t2 tn) ..)
-    (in custom expr, t1  custom expr, t2 custom expr, tn custom expr, left associativity).
-*)
-
-
-Eval compute in [| (0, ()) |].
-Eval compute in [| ((0,0), (0, (0,0))) |].
-
-
-
-Notation "'fun' => t" :=
-     (fun fv_id => (
-          (notype_lambda (t fv_id))))
-     (in custom expr at level 100, t custom expr).
-
-(*
-Notation "( t1 , t2 )" :=
-  (fun (fv_id:nat) => (pp (t1 fv_id) (t2 fv_id)))
-    (in custom expr, t1 custom expr, t2 custom pairs).
-Notation "t1 , t2" :=
-  (fun (fv_id:nat) => (pp (t1 fv_id) (t2 fv_id)))
-    (in custom pairs at level 190, t1 custom pairs, t2 custom expr, left associativity).
-Notation "t" := t (in custom pairs at level 200, t custom expr).
-          (notype_lambda (close 0 (t (S fv_id)) fv_id))))
-     (in custom expr at level 100, x ident, t custom expr).
-
-     *)
-Notation "'fun' f x  => t" :=
-     (fun fv_id => (
-          let x := (fvar fv_id term_var) in
-          (notype_lambda (close 0 (t (S fv_id)) fv_id))))
-     (in custom expr at level 100, f ident, x ident, t custom expr).
-
-Notation "'fun' x  => t" :=
-     (fun fv_id => (
-          let x := (fvar fv_id term_var) in
-          (notype_lambda (close 0 (t (S fv_id)) fv_id))))
-     (in custom expr at level 100, x ident, t custom expr).
-
-Notation "'def_rec' f x => t":=
-     (fun fv_id => (
-        let f := (fvar fv_id term_var) in
-        let x := (fvar (S fv_id) term_var) in
-        (notype_tfix (close 0 (notype_lambda (close 0 (t (S (S fv_id))) (S fv_id))) fv_id) )))
-     (in custom expr at level 100, f ident, x ident, t custom expr).
-
-Notation "'def_rec' f x y => t":=
-     (fun fv_id => (
-          let f := (fvar fv_id term_var) in
-          let x := (fvar (S fv_id) term_var) in
-          let y := (fvar (S (S fv_id)) term_var) in
-          (notype_tfix (
-             close 0 (
-               notype_lambda (
-                 close 0 (
-                    notype_lambda (
-                        close 0 (
-                          t (S(S(S fv_id))))
-                        (S (S fv_id))))
-                 (S fv_id)))
-             fv_id))))
-     (in custom expr at level 100, f ident, x ident, y ident, t custom expr).
-
-Notation " t1 t2 " :=
-  (fun fv_id => (app (t1 fv_id) (t2 fv_id)))
-    (in custom expr at level 200, left associativity,
-        t1 custom expr,
-        t2 custom expr).
-
-
-
-(* Untyped language *)
-(* --------------------------------------------------------------------- *)
-
-Notation "'()'" := (⤳uu) (in custom expr).
-
-Eval compute in [| () |].
-
-Notation "'size' ( t )" := (fun fv_id => (tsize (t fv_id))) (in custom expr,
-                                         t custom expr).
-
-(* Pairs *)
-
-Notation "t '._1'" := (fun fv_id => (pi1 (t fv_id))) (in custom expr at level 200,
-                                  t custom expr).
-
-
-Notation "t '._2'" := (fun fv_id => (pi2 (t fv_id))) (in custom expr at level 200,
-                                  t custom expr).
-
-(* Booleans *)
-Notation "'t_true'" := (⤳ttrue) (in custom expr).
-Notation "'t_false'" := (⤳tfalse) (in custom expr).
-Notation "'if' c 'then' t 'else' f" := (fun fv_id => (ite (c fv_id) (t fv_id) (f fv_id))) (in custom expr at level 1,
-                                                       c custom expr,
-                                                       t custom expr,
-                                                       f custom expr).
-
-
-(* Naturals *)
-Notation "'1'" := (⤳ (succ zero)) (in custom expr).
-Notation "'s' t" := (fun fv_id => (succ (t fv_id))) (in custom expr at level 2,
-                                 t custom expr).
-
-Notation "'match' t 'with' '|' '0' => t1 '|' 's' x => t2 'end'" :=
-  (fun (fv_id:nat) => (
-       tmatch (t fv_id)
-              (t1 fv_id)
-              (let x := (fvar fv_id term_var) in (close 0 (t2 (S fv_id)) fv_id))))
-  (in custom expr at level 190,
-      t custom expr,
-      t1 custom expr,
-      t2 custom expr,
-      x ident).
-
-Eval compute in
-    [| match 0 with
-         |0 => 1
-         |s n => (
-            match n with
-            | 0 => 0
-            | s n' => n' end) end |].
-
-Definition sfr_plus := [|
- def_rec plus x y =>
- (match x with
-     | 0 => y
-     | s x' => (plus x' y) end)
-|].
-
-Example ex1 : wf sfr_plus 0.
-Proof.
-  repeat step.
-Qed.
-
-(* Let expression *)
-Notation "'let' x := t1 'in' t2" :=
-  (fun (fv_id : nat) => (
-       notype_tlet (t1 fv_id)
-                   (let x := (fvar fv_id term_var) in (close 0 (t2 (S fv_id)) fv_id) )))
-    (in custom expr at level 190,
-        t1 custom expr,
-        t2 custom expr,
-        x ident).
-
-Check
-    [| let n := 1 in (match n with
-                                 | 0 => 1
-                                 | s n' => (match n' with
-                                             | 0 => 1
-                                             | s n'' => ((n, n'),n'') end) end) |].
-
-Eval compute in
-[|
- let plus := (def_rec f x y => (
-     match x with
-      | 0 => y
-      | s x' => (f x' y)
-     end))
- in let fibo := (def_rec f n => (
-        match n with
-         | 0 => 1
-         | s n' => (
-             match n' with
-              | 0 => 1
-              | s n'' => plus (f n') (f n'')
-             end)
-        end))
-    in
-    fibo (s (s (s (s (s 0)))))
-|].
-
-
-(* Sum *)
-Notation "'right' t " :=
-  (fun fv_id => tright (t fv_id))
-  (in custom expr at level 180, right associativity, t custom expr).
-Notation "'left' t " := 
-  (fun fv_id => tleft (t fv_id))
-  (in custom expr at level 180, right associativity, t custom expr).
-
-
-Notation "'match' t 'with' '|' 'left' l => t1 '|' 'right' r => t2 'end'" :=
-  (fun (fv_id:nat) => (
-       tmatch (t fv_id)
-              (let l  := (fvar fv_id term_var) in (close 0 (t1 (S fv_id)) fv_id))
-              (let r := (fvar fv_id term_var) in (close 0 (t2 (S fv_id)) fv_id))))
-  (in custom expr at level 190,
-      t custom expr,
-      t1 custom expr,
-      t2 custom expr,
-      l ident,
-      r ident).
-
-Eval compute in [| fun f x => x |].
-
-Eval compute in [| fun f x => fun g y => x |].
-
-
+End Tests.    
 
 
 

--- a/Notations.v
+++ b/Notations.v
@@ -9,167 +9,229 @@ Declare Custom Entry expr.
 Declare Custom Entry type.
 
 (* Entry point *)
-Notation "[| x |]" := x (x custom expr at level 2).
-Notation "( x )" := x (in custom expr, x custom expr).
-Notation "|[ x ]|" := x (in custom expr, x constr).
-Notation "x" := x (in custom expr at level 0, x ident).
+
+Notation "'|' t" := (fun (fv_id:nat) => t) (at level 200).
+Notation "[| x |]" := (x 0) (x custom expr at level 2).
+Notation "( x )" := (fun (fv_id:nat) => (x fv_id)) (in custom expr, x custom expr).
+Notation "x" := (fun fv_id => x) (in custom expr at level 0, x ident). 
 
 (* Variables (nameless) *)
-Notation "'ft{' v '}'" := (fvar v term_var) (in custom expr,
+Notation "'ft{' v '}'" := (| (fvar v term_var)) (in custom expr,
                                                 v constr).
-Notation "'fT{' t '}'" := (fvar t type_var) (in custom type,
-                                                t constr).
-Notation "'lt{' v '}'" := (lvar v term_var) (in custom expr,
+Notation "'lt{' v '}'" := (| (lvar v term_var)) (in custom expr,
                                                 v constr).
-Notation "'lT{' t '}'" := (lvar t type_var) (in custom type at level 4,
-                                                t constr at level 4).
+
+
+Notation "( t1 , t2 )" :=
+  (fun fv_id => (pp (t1 fv_id) (t2 fv_id)))
+  (in custom expr, t1 custom expr, t2 custom expr).
+
+Notation "'0'" := (| zero) (in custom expr).
+
+Notation "'fun' => t" :=
+     (fun fv_id => (
+          (notype_lambda (t fv_id))))
+     (in custom expr at level 100, t custom expr).
+Notation "'fun' ( x ) => t" :=
+     (fun fv_id => (
+          let x := (fvar fv_id term_var) in
+          (notype_lambda (close 0 (t (S fv_id)) fv_id))))
+     (in custom expr at level 100, x ident, t custom expr).
+
+Notation "'fun' f ( x ) => t" :=
+     (fun fv_id => (
+          let x := (fvar fv_id term_var) in
+          (notype_lambda (close 0 (t (S fv_id)) fv_id))))
+     (in custom expr at level 100, f ident, x ident, t custom expr).
+
+Notation "'def_rec' f x => t":=
+     (fun fv_id => (
+        let f := (fvar fv_id term_var) in
+        let x := (fvar (S fv_id) term_var) in
+        (notype_tfix (close 0 (notype_lambda (close 0 (t (S (S fv_id))) (S fv_id))) fv_id) )))
+     (in custom expr at level 100, f ident, x ident, t custom expr).
+
+Notation "'def_rec' f x y => t":=
+     (fun fv_id => (
+          let f := (fvar fv_id term_var) in
+          let x := (fvar (S fv_id) term_var) in
+          let y := (fvar (S (S fv_id)) term_var) in
+          (notype_tfix (
+             close 0 (
+               notype_lambda (
+                 close 0 (
+                    notype_lambda (
+                        close 0 (
+                          t (S(S(S fv_id))))
+                        (S (S fv_id))))
+                 (S fv_id)))
+             fv_id))))
+     (in custom expr at level 100, f ident, x ident, y ident, t custom expr).
+
+Notation " t1 t2 " :=
+  (fun fv_id => (app (t1 fv_id) (t2 fv_id)))
+    (in custom expr at level 200, right associativity,
+        t1 custom expr,
+        t2 custom expr).
+
+Eval compute in [| fun f (x) => (fun g (y) => (x,y)) |].
+
+Eval compute in [| def_rec plus x y => ((plus, x), y) |].
+Eval compute in [| fun set_left (x) => (x, 0) |].
+Eval compute in [| fun truc(x) => (fun truc2(y) => (fun truc3(z) => ((x,y),z))) |].
+
+Eval compute in [| ((ft{0}, 0), 0) |].
+
 (* Untyped language *)
 (* --------------------------------------------------------------------- *)
 
-Notation "'()'" := (uu) (in custom expr).
+Notation "'()'" := (|uu) (in custom expr).
 
-Notation "'size' ( t )" := (tsize t) (in custom expr at level 1,
-                                         t custom expr at level 4).
+Eval compute in [| () |].
 
+Notation "'size' ( t )" := (fun fv_id => (tsize (t fv_id))) (in custom expr,
+                                         t custom expr).
 
-Notation "'fun' => y" := (notype_lambda y) (in custom expr at level 4,
-                                              y custom expr at level 4).
-Notation "'def' f : y" := (notype_lambda y) (in custom expr at level 100,
-                                                f ident,
-                                                y custom expr at level 4).
-Notation " t1 t2 " := (app t1 t2) (in custom expr at level 2,
-                                      t1 custom expr,
-                                      t2 custom expr at level 4).
 (* Pairs *)
 
-Notation "( t1 , t2 , .. , tn )" := (pp .. (pp t1 t2) .. tn) (in custom expr,
-                                           t1 custom expr,
-                                           t2 custom expr,
-                                           tn custom expr).
-Notation "t '._1'" := (pi1 t) (in custom expr at level 2,
+Notation "t '._1'" := (fun fv_id => (pi1 (t fv_id))) (in custom expr at level 200,
                                   t custom expr).
-Notation "t '._2'" := (pi2 t) (in custom expr at level 2,
+Notation "t '._2'" := (fun fv_id => (pi2 (t fv_id))) (in custom expr at level 200,
                                   t custom expr).
 
 (* Booleans *)
-Notation "'true'" := (ttrue) (in custom expr).
-Notation "'false'" := (tfalse) (in custom expr).
-Notation "'if' c 'then' t 'else' f" := (ite c t f) (in custom expr at level 1,
-                                                       c custom expr at level 2,
-                                                       t custom expr at level 4,
-                                                       f custom expr at level 4).
+Notation "'true'" := (|ttrue) (in custom expr).
+Notation "'false'" := (|tfalse) (in custom expr).
+Notation "'if' c 'then' t 'else' f" := (fun fv_id => (ite (c fv_id) (t fv_id) (f fv_id))) (in custom expr at level 1,
+                                                       c custom expr,
+                                                       t custom expr,
+                                                       f custom expr).
 
 (* Naturals *)
-Notation "'0'" := zero (in custom expr).
-Notation "'1'" := (succ zero) (in custom expr).
-Notation "'s' t" := (succ t) (in custom expr at level 2,
+Notation "'1'" := (| (succ zero)) (in custom expr).
+Notation "'s' t" := (fun fv_id => (succ (t fv_id))) (in custom expr at level 2,
                                  t custom expr).
-Notation " t 'match'  '|' t1 '|' t2 'end'" := (tmatch t t1 t2) (in custom expr at level 2,
-                                                              t1 custom expr at level 4,
-                                                              t2 custom expr).
 
-(* Fix points *)
-(* Notation "'fix' t" := (notype_tfix t) (in custom expr at level 2,
-                                          t custom expr).
-*)
+Notation "'match' t 'with' '|' '0' => t1 '|' 's' x => t2 'end'" :=
+  (fun (fv_id:nat) => (
+       tmatch (t fv_id)
+              (t1 fv_id)
+              (let x := (fvar fv_id term_var) in (close 0 (t2 (S fv_id)) fv_id))))
+  (in custom expr at level 190,
+      t custom expr,
+      t1 custom expr,
+      t2 custom expr,
+      x ident).
+
+Eval compute in
+    [| match 0 with
+         |0 => 1
+         |s n => (
+            match n with
+            | 0 => 0
+            | s n' => n' end) end |].
+
+Definition sfr_plus := [|
+ def_rec plus x y =>
+ (match x with
+     | 0 => y
+     | s x' => (plus x' y) end)
+|].
+
+Example ex1 : wf sfr_plus 0.
+Proof.
+  repeat step.
+Qed.
+
 (* Let expression *)
-Notation "'let' := t1 'in' t2" := (notype_tlet t1 t2) (in custom expr at level 1,
-                                                       t1 custom expr at level 4,
-                                                       t2 custom expr at level 4).
+Notation "'let' x := t1 'in' t2" :=
+  (fun (fv_id : nat) => (
+       notype_tlet (t1 fv_id)
+                   (let x := (fvar fv_id term_var) in (close 0 (t2 (S fv_id)) fv_id) )))
+    (in custom expr at level 190,
+        t1 custom expr,
+        t2 custom expr,
+        x ident).
+
+Check
+    [| let n := 1 in (match n with
+                                 | 0 => 1
+                                 | s n' => (match n' with
+                                             | 0 => 1
+                                             | s n'' => ((n, n'),n'') end) end) |].
+
+Eval compute in
+[|
+ let plus := (def_rec f x y => (match x with
+                                    | 0 => y
+                                    | s x' => (f x' y) end)) in (
+ let fibo := (def_rec f n => (match n with
+                                 | 0 => 1
+                                 | s n' => (match n' with
+                                             | 0 => 1
+                                             | s n'' => plus (f n') (f n'') end) end))
+                 in fibo (s (s (s (s (s 0))))))
+|].
+
+
 (* Sum *)
-Notation "'right' ( t )" := (tright t) (in custom expr at level 2,
-                                         t custom expr at level 4).
-Notation "'left' ( t )" := (tleft t) (in custom expr at level 2,
-                                         t custom expr at level 4).
-Notation "t 'match' '|' 'left' => t1 '|' 'right' => t2 'end'" := (sum_match t t1 t2) (in custom expr at level 2,
-                                                                                       t custom expr,
-                                                                                       t1 custom expr,
-                                                                                       t2 custom expr).
+Notation "'right' t " :=
+  (fun fv_id => tright (t fv_id))
+  (in custom expr at level 180, right associativity, t custom expr).
+Notation "'left' t " := 
+  (fun fv_id => tleft (t fv_id))
+  (in custom expr at level 180, right associativity, t custom expr).
 
-Notation "'fun' [ T ] => y" := (lambda T y) (in custom expr at level 4,
-                                               T custom type at level 4,
-                                               y custom expr at level 4).
 
-Definition fresh_id (t: tree) := makeFresh (fv t :: nil).
-
-Notation "'fun' ( x ) => t" :=
-   (let fresh := (S (let x := (fvar 0 term_var) in (max (fv t)))) in 
-    let x     := (fvar fresh term_var) in
-    notype_lambda (close 0 t fresh))
-     (in custom expr at level 100, x ident, t custom expr).
+Notation "'match' t 'with' '|' 'left' l => t1 '|' 'right' r => t2 'end'" :=
+  (fun (fv_id:nat) => (
+       tmatch (t fv_id)
+              (let l  := (fvar fv_id term_var) in (close 0 (t1 (S fv_id)) fv_id))
+              (let r := (fvar fv_id term_var) in (close 0 (t2 (S fv_id)) fv_id))))
+  (in custom expr at level 190,
+      t custom expr,
+      t1 custom expr,
+      t2 custom expr,
+      l ident,
+      r ident).
 
 Eval compute in [| fun ( x ) => x |].
 
-  (*
-Notation "'fun' ( x ) => t" :=
-   (let fresh := fresh_id (let x := (fvar 0 term_var) in t) in
-   ((fun x => (fvar fresh term_var))
-   (notype_lambda (close 0 t fresh)))) (in custom expr at level 100, x ident, t custom expr). *)
-
 Eval compute in [| fun ( x ) => (fun (y) => x) |].
-Example test1 : [| fun ( x ) => (x, (fun (y) => (x, y)), x) |] = [| fun => ((lt{0}, (fun => (lt{1}, lt{0}))), lt{0}) |].
+Example test1 : [| fun ( x ) => ((x, fun (y) => (x, y)), x) |] = [| fun => ((lt{0}, (fun => (lt{1}, lt{0}))), lt{0}) |].
 Proof.
-  unfold fv, pfv, max.
-  simpl.
-  assert (forall t:nat, (if tag_eq_dec term_var term_var then singleton t else nil) = (singleton t)) as H. {
-    destruct (tag_eq_dec term_var term_var) eqn:E.
-    reflexivity.
-    congruence. }
-  rewrite ?H.
-  simpl.
-  reflexivity.
-Qed.
+  repeat step.
+  Qed.
 
 Eval compute in [| fun ( x ) => (fun (y) => x)|].
-
-Notation "'def_rec' f '(' x ')' := t" :=
-  (let f := (fvar 1000 term_var) in
-   let x := (fvar 999 term_var) in
-   (notype_tfix (close 0 (close 1 t 999) 1000)))
-  (in custom expr at level 100, f ident, x ident, t custom expr, right associativity).
-
 
 
 Eval compute in [|
      fun (x) => (fun (y) => ((x,y), fun(z) => (x, y))) |].
 
-Eval compute in [|
-(
-def_rec plus(pair) :=
-  pair._1 match
-    | pair._2
-    | fun(x) => s (plus (x, pair._2))
-  end
-) (0, 0)
-|].
-
-Notation "'λ' f" := (notype_lambda (close 0 (f (fvar 1000 term_var)) 1000))
-  (at level 300, right associativity).
-
-Eval compute in (λ (fun x => (pp x (notype_lambda x)))).
 (* Examples *)
 (* --------------------------------------------------------------------- *)
 
 (* Unset Printing Notations. *)
 
-Example ex1: wf [| if true then 0 else 1 |] 0.
+Example ex11: wf [| if true then 0 else 1 |] 0.
 Proof. repeat step. Qed.
 
 Example ex2: wf [|
-                 fun => lt{0} match
-                       | left => 0
-                       | right => 1 end
+                 fun => match lt{0} with
+                       | left x => 0
+                       | right x => 1 end
                 |] 0.
 Proof. repeat step. Qed.
 
 Example ex3: wf [|
-                 fun => let := (s 1) in
-                     if lt{0} then (
-                         lt{1} match
-                           | 1
-                           | (fun => (s lt{2})) end)
+                 fun => let x := (s 1) in
+                     if x then (
+                         match 0 with
+                           | 0 => 1
+                           | s _ => x  end)
                      else (
-                         let := 0 in ()
+                         let y := 0 in ()
                        )
                  |] 0.
 Proof. repeat step. Qed.
@@ -177,14 +239,6 @@ Proof. repeat step. Qed.
 (* close free variable -> local variable *)
 
 
-Compute tree_size [|
-         let zero := s 0 in lt{0} match
-         | s 0
-             | s (s 0) end
-|].
-
-
-Compute close 0 (notype_lambda ((fvar 5 term_var))) 5.
 
 
 

--- a/Notations.v
+++ b/Notations.v
@@ -25,6 +25,15 @@ Module UnTyped.
   (* Base terms *)
   Notation "'0'" := (⤳ zero) (in custom expr).
   Notation "'1'" := (⤳ (succ zero)) (in custom expr).
+  Notation "'2'" := (⤳ (succ (succ zero))) (in custom expr).
+  Notation "'3'" := (⤳ (succ (succ (succ zero)))) (in custom expr).
+  Notation "'4'" := (⤳ (succ (succ (succ (succ zero))))) (in custom expr).
+  Notation "'5'" := (⤳ (succ (succ (succ (succ (succ zero)))))) (in custom expr).
+  Notation "'6'" := (⤳ (succ (succ (succ (succ (succ (succ zero))))))) (in custom expr).
+  Notation "'7'" := (⤳ (succ (succ (succ (succ (succ (succ (succ zero)))))))) (in custom expr).
+  Notation "'8'" := (⤳ (succ (succ (succ (succ (succ (succ (succ (succ zero))))))))) (in custom expr).
+  Notation "'9'" := (⤳ (succ (succ (succ (succ (succ (succ (succ (succ (succ zero)))))))))) (in custom expr).
+  
   Notation "'()'" := (⤳ uu) (in custom expr).
   Notation "'t_true'" := (⤳ttrue) (in custom expr).
   Notation "'t_false'" := (⤳tfalse) (in custom expr).

--- a/Notations.v
+++ b/Notations.v
@@ -1,0 +1,164 @@
+Require Export SystemFR.Trees.
+Require Export SystemFR.Syntax.
+
+
+Open Scope list.
+
+Declare Custom Entry expr.
+Declare Custom Entry type.
+
+(* Entry point *)
+Notation "[| x |]" := x (x custom expr at level 2).
+Notation "( x )" := x (in custom expr, x custom expr).
+Notation "|[ x ]|" := x (in custom expr, x constr).
+Notation "x" := x (in custom expr at level 0, x ident).
+
+(* Variables (nameless) *)
+Notation "'ft{' v '}'" := (fvar v term_var) (in custom expr at level 4,
+                                                v constr at level 4).
+Notation "'fT{' t '}'" := (fvar t type_var) (in custom type,
+                                                t constr).
+Notation "'lt{' v '}'" := (lvar v term_var) (in custom expr,
+                                                v constr).
+Notation "'lT{' t '}'" := (lvar t type_var) (in custom type at level 4,
+                                                t constr at level 4).
+(* Untyped language *)
+(* --------------------------------------------------------------------- *)
+
+Notation "'()'" := (uu) (in custom expr).
+
+Notation "'size' ( t )" := (tsize t) (in custom expr at level 1,
+                                         t custom expr at level 4).
+
+
+Notation "'fun' => y" := (notype_lambda y) (in custom expr at level 4,
+                                              y custom expr at level 4).
+Notation "'def' f : y" := (notype_lambda y) (in custom expr at level 100,
+                                                f ident,
+                                                y custom expr at level 4).
+Notation " t1 t2 " := (app t1 t2) (in custom expr at level 2,
+                                      t1 custom expr,
+                                      t2 custom expr at level 4).
+(* Pairs *)
+
+Notation "( t1 , t2 , .. , tn )" := (pp .. (pp t1 t2) .. tn) (in custom expr,
+                                           t1 custom expr,
+                                           t2 custom expr,
+                                           tn custom expr).
+Notation "t '._1'" := (pi1 t) (in custom expr at level 2,
+                                  t custom expr).
+Notation "t '._2'" := (pi2 t) (in custom expr at level 2,
+                                  t custom expr).
+
+(* Booleans *)
+Notation "'true'" := (ttrue) (in custom expr).
+Notation "'false'" := (tfalse) (in custom expr).
+Notation "'if' c 'then' t 'else' f" := (ite c t f) (in custom expr at level 1,
+                                                       c custom expr at level 2,
+                                                       t custom expr at level 4,
+                                                       f custom expr at level 4).
+
+(* Naturals *)
+Notation "'0'" := zero (in custom expr).
+Notation "'1'" := (succ zero) (in custom expr).
+Notation "'s' t" := (succ t) (in custom expr at level 2,
+                                 t custom expr).
+Notation " t 'match'  '|' t1 '|' t2 'end'" := (tmatch t t1 t2) (in custom expr at level 2,
+                                                              t1 custom expr at level 4,
+                                                              t2 custom expr).
+
+(* Fix points *)
+Notation "'fix' t" := (notype_tfix t) (in custom expr at level 2,
+                                          t custom expr).
+
+(* Let expression *)
+Notation "'let' := t1 'in' t2" := (notype_tlet t1 t2) (in custom expr at level 1,
+                                                       t1 custom expr at level 4,
+                                                       t2 custom expr at level 4).
+(* Sum *)
+Notation "'right' ( t )" := (tright t) (in custom expr at level 2,
+                                         t custom expr at level 4).
+Notation "'left' ( t )" := (tleft t) (in custom expr at level 2,
+                                         t custom expr at level 4).
+Notation "t 'match' '|' 'left' => t1 '|' 'right' => t2 'end'" := (sum_match t t1 t2) (in custom expr at level 2,
+                                                                                       t custom expr,
+                                                                                       t1 custom expr,
+                                                                                       t2 custom expr).
+
+Notation "'fun' [ T ] => y" := (lambda T y) (in custom expr at level 4,
+                                               T custom type at level 4,
+                                               y custom expr at level 4).
+
+Notation "'fun' ( x ) => t" :=
+  (let x := (fvar 1000 term_var) in
+   (notype_lambda (close 0 t 1000))) (in custom expr at level 100, x ident, t custom expr).
+
+Notation "'def_rec' f '(' x ')' := t" :=
+  (let f := (lvar 1000 term_var) in
+   let x := (fvar 999 term_var) in
+   (notype_tfix (close 0 (close 1 t 999) 1000))
+  (in custom expr at level 100, f ident, x ident, t custom expr, right associativity).
+
+
+
+Eval compute in [|
+(
+def_rec plus(pair) :=
+  pair._1 match
+    | pair._2
+    | fun(x) => s (plus (x, pair._2))
+  end
+) (0, 0)
+|].
+
+Notation "'λ' f" := (notype_lambda (close 0 (f (fvar 1000 term_var)) 1000))
+  (at level 300, right associativity).
+
+Eval compute in (λ (fun x => (pp x (notype_lambda x)))).
+(* Examples *)
+(* --------------------------------------------------------------------- *)
+
+(* Unset Printing Notations. *)
+
+Example ex1: wf [| if true then 0 else 1 |] 0.
+Proof. repeat step. Qed.
+
+Example ex2: wf [|
+                 fun => lt{0} match
+                       | left => 0
+                       | right => 1 end
+                |] 0.
+Proof. repeat step. Qed.
+
+Example ex3: wf [|
+                 fun => let := (s 1) in
+                     if lt{0} then (
+                         lt{1} match
+                           | 1
+                           | (fun => (s lt{2})) end)
+                     else (
+                         let := 0 in ()
+                       )
+                 |] 0.
+Proof. repeat step. Qed.
+
+(* close free variable -> local variable *)
+
+
+Compute tree_size [|
+         let zero := s 0 in lt{0} match
+         | s 0
+             | s (s 0) end
+|].
+
+
+Compute close 0 (notype_lambda ((fvar 5 term_var))) 5.
+
+
+
+
+
+
+
+
+

--- a/Notations.v
+++ b/Notations.v
@@ -74,7 +74,7 @@ Notation "( t1 , .. , t2 , tn )" :=
       (in custom expr at level 100, f ident, x ident, y ident, t custom expr).
   Notation " t1 t2 " :=
     (fun fv_id => (app (t1 fv_id) (t2 fv_id)))
-      (in custom expr at level 50, right associativity,
+      (in custom expr at level 50, left associativity,
           t1 custom expr,
           t2 custom expr).
 

--- a/Notations.v
+++ b/Notations.v
@@ -9,7 +9,7 @@ Declare Custom Entry expr.
 Declare Custom Entry type.
 
 (* Entry point *)
-Notation "'|' t" := (fun (fv_id:nat) => t) (at level 100).
+Notation "'⤳' t" := (fun (fv_id:nat) => t) (at level 100).
 Notation "[| x |]" := (x 0) (x custom expr).
 Notation "[|| x ||]" := (x 0) (x custom type).
 Notation "( x )" := (fun (fv_id:nat) => (x fv_id)) (in custom expr, x custom expr).
@@ -18,18 +18,18 @@ Notation "( x )" := (fun (fv_id:nat) => (x fv_id)) (in custom type, x custom typ
 Notation "x" := (fun fv_id => x) (in custom type at level 0, x ident). 
 
 (* Variables (nameless) *)
-Notation "'ft{' v '}'" := (| (fvar v term_var)) (in custom expr, v constr).
-Notation "'lt{' v '}'" := (| (lvar v term_var)) (in custom expr, v constr).
-Notation "'fT{' v '}'" := (| (fvar v type_var)) (in custom expr, v constr).
-Notation "'lT{' v '}'" := (| (lvar v type_var)) (in custom expr, v constr).
+Notation "'ft{' v '}'" := (⤳ (fvar v term_var)) (in custom expr, v constr).
+Notation "'lt{' v '}'" := (⤳ (lvar v term_var)) (in custom expr, v constr).
+Notation "'fT{' v '}'" := (⤳ (fvar v type_var)) (in custom expr, v constr).
+Notation "'lT{' v '}'" := (⤳ (lvar v type_var)) (in custom expr, v constr).
 
 
 (* Types *) (* constr and custom entries share the same lexer --' ) (WTF?)*)
-Notation "'Nat'" := (| T_nat) (in custom type).
-Notation "'Unit'" := (| T_unit) (in custom type).
-Notation "'Bool'" := (| T_bool) (in custom type).
-Notation "'⊤'" := (| T_top) (in custom type).
-Notation "'⊥'" := (| T_bot) (in custom type).
+Notation "'Nat'" := (⤳ T_nat) (in custom type).
+Notation "'Unit'" := (⤳ T_unit) (in custom type).
+Notation "'Bool'" := (⤳ T_bool) (in custom type).
+Notation "'⊤'" := (⤳ T_top) (in custom type).
+Notation "'⊥'" := (⤳ T_bot) (in custom type).
 
 Example base_types : ([|| Nat ||], [|| Unit ||], [|| Bool ||], [|| ⊤ ||], [|| ⊥ ||]) = (T_nat, T_unit, T_bool, T_top, T_bot). Proof. reflexivity. Qed.
 
@@ -128,8 +128,8 @@ Eval compute in
 (* Terms *)
 
 (* Base terms *)
-Notation "'0'" := (| zero) (in custom expr).
-Notation "'()'" := (| uu) (in custom expr).
+Notation "'0'" := (⤳ zero) (in custom expr).
+Notation "'()'" := (⤳ uu) (in custom expr).
 
 Notation "'error'" := (notype_err) (in custom expr).
 Notation "'error' [ T ] " := (fun fv_id => err (T fv_id)) (in custom expr, T custom type).
@@ -219,7 +219,7 @@ Notation " t1 t2 " :=
 (* Untyped language *)
 (* --------------------------------------------------------------------- *)
 
-Notation "'()'" := (|uu) (in custom expr).
+Notation "'()'" := (⤳uu) (in custom expr).
 
 Eval compute in [| () |].
 
@@ -234,15 +234,15 @@ Notation "t '._2'" := (fun fv_id => (pi2 (t fv_id))) (in custom expr at level 20
                                   t custom expr).
 
 (* Booleans *)
-Notation "'true'" := (|ttrue) (in custom expr).
-Notation "'false'" := (|tfalse) (in custom expr).
+Notation "'true'" := (⤳ttrue) (in custom expr).
+Notation "'false'" := (⤳tfalse) (in custom expr).
 Notation "'if' c 'then' t 'else' f" := (fun fv_id => (ite (c fv_id) (t fv_id) (f fv_id))) (in custom expr at level 1,
                                                        c custom expr,
                                                        t custom expr,
                                                        f custom expr).
 
 (* Naturals *)
-Notation "'1'" := (| (succ zero)) (in custom expr).
+Notation "'1'" := (⤳ (succ zero)) (in custom expr).
 Notation "'s' t" := (fun fv_id => (succ (t fv_id))) (in custom expr at level 2,
                                  t custom expr).
 

--- a/Notations.v
+++ b/Notations.v
@@ -9,40 +9,180 @@ Declare Custom Entry expr.
 Declare Custom Entry type.
 
 (* Entry point *)
-
-Notation "'|' t" := (fun (fv_id:nat) => t) (at level 200).
-Notation "[| x |]" := (x 0) (x custom expr at level 2).
+Notation "'|' t" := (fun (fv_id:nat) => t) (at level 100).
+Notation "[| x |]" := (x 0) (x custom expr).
+Notation "[|| x ||]" := (x 0) (x custom type).
 Notation "( x )" := (fun (fv_id:nat) => (x fv_id)) (in custom expr, x custom expr).
 Notation "x" := (fun fv_id => x) (in custom expr at level 0, x ident). 
+Notation "( x )" := (fun (fv_id:nat) => (x fv_id)) (in custom type, x custom type).
+Notation "x" := (fun fv_id => x) (in custom type at level 0, x ident). 
 
 (* Variables (nameless) *)
-Notation "'ft{' v '}'" := (| (fvar v term_var)) (in custom expr,
-                                                v constr).
-Notation "'lt{' v '}'" := (| (lvar v term_var)) (in custom expr,
-                                                v constr).
+Notation "'ft{' v '}'" := (| (fvar v term_var)) (in custom expr, v constr).
+Notation "'lt{' v '}'" := (| (lvar v term_var)) (in custom expr, v constr).
+Notation "'fT{' v '}'" := (| (fvar v type_var)) (in custom expr, v constr).
+Notation "'lT{' v '}'" := (| (lvar v type_var)) (in custom expr, v constr).
 
 
+(* Types *) (* constr and custom entries share the same lexer --' ) (WTF?)*)
+Notation "'Nat'" := (| T_nat) (in custom type).
+Notation "'Unit'" := (| T_unit) (in custom type).
+Notation "'Bool'" := (| T_bool) (in custom type).
+Notation "'⊤'" := (| T_top) (in custom type).
+Notation "'⊥'" := (| T_bot) (in custom type).
+
+Example base_types : ([|| Nat ||], [|| Unit ||], [|| Bool ||], [|| ⊤ ||], [|| ⊥ ||]) = (T_nat, T_unit, T_bool, T_top, T_bot). Proof. reflexivity. Qed.
+
+Notation "[ t1 ≡ t2 ]" :=
+  (fun fv_id => (T_equiv (t1 fv_id) (t2 fv_id)))
+    (in custom type at level 200,
+     t1 custom expr,
+     t2 custom expr).
+
+Notation "τ1 -> τ2" := (fun fv_id => (T_arrow (τ1 fv_id) (τ2 fv_id))) (in custom type at level 90, right associativity, τ1 custom type, τ2 custom type).
+Notation "x : τ1 -> τ2" :=
+  (fun fv_id => (
+       let x := (fvar fv_id term_var) in
+       (T_arrow (τ1 fv_id) (close 0 (τ2 (S fv_id)) fv_id ))))
+    (in custom type, τ1 custom type at level 85, τ2 custom type at next level, x ident).
+
+Example arrow_type1 : [|| (Nat -> Bool) -> Unit -> ⊤ ||] = T_arrow (T_arrow T_nat T_bool) (T_arrow T_unit T_top).
+Proof. reflexivity. Qed.
+Example arrow_type2 : [|| x : Nat -> y : Nat -> [x ≡ y] ||] = T_arrow T_nat (T_arrow T_nat (T_equiv (lvar 1 term_var) (lvar 0 term_var))).
+Proof. reflexivity. Qed.
+
+
+Notation "τ1 * τ2" :=(fun fv_id => (T_prod (τ1 fv_id) (τ2 fv_id))) (in custom type at level 90, right associativity, τ1 custom type, τ2 custom type).
+
+Notation "x : τ1 * τ2" :=
+  (fun fv_id => (
+       let x := (fvar fv_id term_var) in
+       (T_prod (τ1 fv_id) (close 0 (τ2 (S fv_id)) fv_id ))))
+    (in custom type, τ1 custom type at level 85, τ2 custom type at level 100, x ident).
+
+
+Example prod_type1 : [|| Nat * Bool ||] = T_prod T_nat T_bool.
+Proof. simpl. reflexivity. Qed.
+Example prod_type2 : [|| x : Nat * Bool * Unit ||] = T_prod T_nat (T_prod T_bool T_unit).
+Proof. reflexivity. Qed.
+
+
+Notation "τ1 + τ2" :=
+  (fun fv_id => (T_sum (τ1 fv_id) (τ2 fv_id))) (in custom type at level 95, τ1 custom type, τ2 custom type).
+
+Eval compute in [|| Bool -> Nat + Unit ||].
+
+Example sum_type1 : [|| Bool -> Nat + Unit ||] = T_sum (T_arrow T_bool T_nat) T_unit.
+Proof. reflexivity. Qed.
+
+Example sum_type2 : [|| Nat + x : Bool -> y : Nat * [x ≡ y] + Nat ||] =  T_sum T_nat (T_arrow T_bool (T_prod T_nat (T_sum (T_equiv (lvar 1 term_var) (lvar 0 term_var)) T_nat))).
+Proof. reflexivity. Qed.
+
+
+Notation "{ x : τ1 | t }" :=
+  (fun fv_id => (
+       let x := (fvar fv_id term_var) in
+       (T_refine (τ1 fv_id) (close 0 (t (S fv_id)) fv_id))))
+    (in custom type at level 200, τ1 custom type, t custom expr, x ident).
+
+Example refine_type1 : [|| { x : Bool | x } ||] = T_refine T_bool (lvar 0 term_var).
+Proof. reflexivity. Qed.
+
+Notation "{{ x : τ1 | τ2 }}" :=
+  (fun fv_id => (
+       let x := (fvar fv_id term_var) in
+       (T_type_refine (τ1 fv_id) (close 0 (τ2 (S fv_id)) fv_id))))
+    (in custom type at level 200, τ1 custom type, τ2 custom type, x ident).
+
+Example refine_by_type1 : [|| {{ x : Bool | [x ≡ x] }} ||] = (T_type_refine T_bool (T_equiv (lvar 0 term_var) (lvar 0 term_var))).
+Proof. reflexivity. Qed.
+
+Notation "τ1 ∪ τ2" :=
+  (fun fv_id => (T_union (τ1 fv_id) (τ2 fv_id))) (in custom type at level 190, right associativity, τ1 custom type, τ2 custom type).
+Notation "τ1 ∩ τ2" :=
+  (fun fv_id => (T_intersection (τ1 fv_id) (τ2 fv_id))) (in custom type at level 170, right associativity, τ1 custom type, τ2 custom type).
+
+Example union_type1 : [|| Nat ∩ Bool ∪ Nat ||] = T_union (T_intersection T_nat T_bool) T_nat.
+Proof. reflexivity. Qed.
+
+(*
+Notation "'forall' x : τ1 . τ2" :=
+  (fun fv_id => (
+       let x := (fvar fv_id term_var) in
+       (T_intersection (τ1 fv_id) (close 0 (τ2 (S fv_id)) fv_id))))
+    (in custom type at level 190, right associativity, τ1 custom type, τ2 custom type).
+Notation "'forall' α : 'Type' . τ1 ":=
+  (fun fv_id => (
+       let α := (fvar fv_id type_var) in
+       (T_abs (tclose 0 (τ1 (S fv_id)) fv_id))))
+    (in custom type at level 190, right associativity, τ1 custom type, α ident).
+
+(* Tests *)
+Eval compute in
+    [|| Nat ||].
+Eval compute in
+[||  Nat ∩ Bool ∪ Unit ∪ (forall x : Type . Nat) ||]. *)
+                   
+
+
+(* Terms *)
+
+(* Base terms *)
+Notation "'0'" := (| zero) (in custom expr).
+Notation "'()'" := (| uu) (in custom expr).
+
+Notation "'error'" := (notype_err) (in custom expr).
+Notation "'error' [ T ] " := (fun fv_id => err (T fv_id)) (in custom expr, T custom type).
+
+(* Pairs *)
 Notation "( t1 , t2 )" :=
-  (fun fv_id => (pp (t1 fv_id) (t2 fv_id)))
+  (fun (fv_id:nat) => (pp (t1 fv_id) (t2 fv_id)))
   (in custom expr, t1 custom expr, t2 custom expr).
 
-Notation "'0'" := (| zero) (in custom expr).
+(*
+Needs Coq 8.11 to work
+Definition pp_notation (p1 : nat -> tree) (p2 : nat -> tree) : (nat -> tree) :=
+  fun (fv_id : nat) => pp (p1 fv_id) (p2 fv_id).
+
+Notation "( t1 , .. , t2 , tn )" :=
+  (pp_notation  t1 .. (pp_notation t2 tn) ..)
+    (in custom expr, t1  custom expr, t2 custom expr, tn custom expr, left associativity).
+*)
+
+
+Eval compute in [| (0, ()) |].
+Eval compute in [| ((0,0), (0, (0,0))) |].
+
+
 
 Notation "'fun' => t" :=
      (fun fv_id => (
           (notype_lambda (t fv_id))))
      (in custom expr at level 100, t custom expr).
-Notation "'fun' ( x ) => t" :=
-     (fun fv_id => (
-          let x := (fvar fv_id term_var) in
+
+(*
+Notation "( t1 , t2 )" :=
+  (fun (fv_id:nat) => (pp (t1 fv_id) (t2 fv_id)))
+    (in custom expr, t1 custom expr, t2 custom pairs).
+Notation "t1 , t2" :=
+  (fun (fv_id:nat) => (pp (t1 fv_id) (t2 fv_id)))
+    (in custom pairs at level 190, t1 custom pairs, t2 custom expr, left associativity).
+Notation "t" := t (in custom pairs at level 200, t custom expr).
           (notype_lambda (close 0 (t (S fv_id)) fv_id))))
      (in custom expr at level 100, x ident, t custom expr).
 
-Notation "'fun' f ( x ) => t" :=
+     *)
+Notation "'fun' f x  => t" :=
      (fun fv_id => (
           let x := (fvar fv_id term_var) in
           (notype_lambda (close 0 (t (S fv_id)) fv_id))))
      (in custom expr at level 100, f ident, x ident, t custom expr).
+
+Notation "'fun' x  => t" :=
+     (fun fv_id => (
+          let x := (fvar fv_id term_var) in
+          (notype_lambda (close 0 (t (S fv_id)) fv_id))))
+     (in custom expr at level 100, x ident, t custom expr).
 
 Notation "'def_rec' f x => t":=
      (fun fv_id => (
@@ -74,13 +214,7 @@ Notation " t1 t2 " :=
         t1 custom expr,
         t2 custom expr).
 
-Eval compute in [| fun f (x) => (fun g (y) => (x,y)) |].
 
-Eval compute in [| def_rec plus x y => ((plus, x), y) |].
-Eval compute in [| fun set_left (x) => (x, 0) |].
-Eval compute in [| fun truc(x) => (fun truc2(y) => (fun truc3(z) => ((x,y),z))) |].
-
-Eval compute in [| ((ft{0}, 0), 0) |].
 
 (* Untyped language *)
 (* --------------------------------------------------------------------- *)
@@ -162,15 +296,22 @@ Check
 
 Eval compute in
 [|
- let plus := (def_rec f x y => (match x with
-                                    | 0 => y
-                                    | s x' => (f x' y) end)) in (
- let fibo := (def_rec f n => (match n with
-                                 | 0 => 1
-                                 | s n' => (match n' with
-                                             | 0 => 1
-                                             | s n'' => plus (f n') (f n'') end) end))
-                 in fibo (s (s (s (s (s 0))))))
+ let plus := (def_rec f x y => (
+     match x with
+      | 0 => y
+      | s x' => (f x' y)
+     end))
+ in let fibo := (def_rec f n => (
+        match n with
+         | 0 => 1
+         | s n' => (
+             match n' with
+              | 0 => 1
+              | s n'' => plus (f n') (f n'')
+             end)
+        end))
+    in
+    fibo (s (s (s (s (s 0)))))
 |].
 
 
@@ -195,54 +336,9 @@ Notation "'match' t 'with' '|' 'left' l => t1 '|' 'right' r => t2 'end'" :=
       l ident,
       r ident).
 
-Eval compute in [| fun ( x ) => x |].
+Eval compute in [| fun f x => x |].
 
-Eval compute in [| fun ( x ) => (fun (y) => x) |].
-Example test1 : [| fun ( x ) => ((x, fun (y) => (x, y)), x) |] = [| fun => ((lt{0}, (fun => (lt{1}, lt{0}))), lt{0}) |].
-Proof.
-  repeat step.
-  Qed.
-
-Eval compute in [| fun ( x ) => (fun (y) => x)|].
-
-
-Eval compute in [|
-     fun (x) => (fun (y) => ((x,y), fun(z) => (x, y))) |].
-
-(* Examples *)
-(* --------------------------------------------------------------------- *)
-
-(* Unset Printing Notations. *)
-
-Example ex11: wf [| if true then 0 else 1 |] 0.
-Proof. repeat step. Qed.
-
-Example ex2: wf [|
-                 fun => match lt{0} with
-                       | left x => 0
-                       | right x => 1 end
-                |] 0.
-Proof. repeat step. Qed.
-
-Example ex3: wf [|
-                 fun => let x := (s 1) in
-                     if x then (
-                         match 0 with
-                           | 0 => 1
-                           | s _ => x  end)
-                     else (
-                         let y := 0 in ()
-                       )
-                 |] 0.
-Proof. repeat step. Qed.
-
-(* close free variable -> local variable *)
-
-
-
-
-
-
+Eval compute in [| fun f x => fun g y => x |].
 
 
 

--- a/Notations.v
+++ b/Notations.v
@@ -112,7 +112,7 @@ Notation "( t1 , .. , t2 , tn )" :=
       (in custom expr at level 180, right associativity, t custom expr).
   Notation "'match' t 'with' '|' 'left' l => t1 '|' 'right' r => t2 'end'" :=
     (fun (fv_id:nat) => (
-         tmatch (t fv_id)
+         sum_match (t fv_id)
                 (let l  := (fvar fv_id term_var) in (close 0 (t1 (S fv_id)) fv_id))
                 (let r := (fvar fv_id term_var) in (close 0 (t2 (S fv_id)) fv_id))))
       (in custom expr at level 190, t custom expr, t1 custom expr, t2 custom expr, l ident, r ident).

--- a/Notations.v
+++ b/Notations.v
@@ -1,5 +1,6 @@
 Require Export SystemFR.Trees.
 Require Export SystemFR.Syntax.
+Require Export SystemFR.Freshness.
 
 
 Open Scope list.
@@ -14,8 +15,8 @@ Notation "|[ x ]|" := x (in custom expr, x constr).
 Notation "x" := x (in custom expr at level 0, x ident).
 
 (* Variables (nameless) *)
-Notation "'ft{' v '}'" := (fvar v term_var) (in custom expr at level 4,
-                                                v constr at level 4).
+Notation "'ft{' v '}'" := (fvar v term_var) (in custom expr,
+                                                v constr).
 Notation "'fT{' t '}'" := (fvar t type_var) (in custom type,
                                                 t constr).
 Notation "'lt{' v '}'" := (lvar v term_var) (in custom expr,
@@ -68,9 +69,9 @@ Notation " t 'match'  '|' t1 '|' t2 'end'" := (tmatch t t1 t2) (in custom expr a
                                                               t2 custom expr).
 
 (* Fix points *)
-Notation "'fix' t" := (notype_tfix t) (in custom expr at level 2,
+(* Notation "'fix' t" := (notype_tfix t) (in custom expr at level 2,
                                           t custom expr).
-
+*)
 (* Let expression *)
 Notation "'let' := t1 'in' t2" := (notype_tlet t1 t2) (in custom expr at level 1,
                                                        t1 custom expr at level 4,
@@ -89,17 +90,48 @@ Notation "'fun' [ T ] => y" := (lambda T y) (in custom expr at level 4,
                                                T custom type at level 4,
                                                y custom expr at level 4).
 
+Definition fresh_id (t: tree) := makeFresh (fv t :: nil).
+
 Notation "'fun' ( x ) => t" :=
-  (let x := (fvar 1000 term_var) in
-   (notype_lambda (close 0 t 1000))) (in custom expr at level 100, x ident, t custom expr).
+   (let fresh := (S (let x := (fvar 0 term_var) in (max (fv t)))) in 
+    let x     := (fvar fresh term_var) in
+    notype_lambda (close 0 t fresh))
+     (in custom expr at level 100, x ident, t custom expr).
+
+Eval compute in [| fun ( x ) => x |].
+
+  (*
+Notation "'fun' ( x ) => t" :=
+   (let fresh := fresh_id (let x := (fvar 0 term_var) in t) in
+   ((fun x => (fvar fresh term_var))
+   (notype_lambda (close 0 t fresh)))) (in custom expr at level 100, x ident, t custom expr). *)
+
+Eval compute in [| fun ( x ) => (fun (y) => x) |].
+Example test1 : [| fun ( x ) => (x, (fun (y) => (x, y)), x) |] = [| fun => ((lt{0}, (fun => (lt{1}, lt{0}))), lt{0}) |].
+Proof.
+  unfold fv, pfv, max.
+  simpl.
+  assert (forall t:nat, (if tag_eq_dec term_var term_var then singleton t else nil) = (singleton t)) as H. {
+    destruct (tag_eq_dec term_var term_var) eqn:E.
+    reflexivity.
+    congruence. }
+  rewrite ?H.
+  simpl.
+  reflexivity.
+Qed.
+
+Eval compute in [| fun ( x ) => (fun (y) => x)|].
 
 Notation "'def_rec' f '(' x ')' := t" :=
-  (let f := (lvar 1000 term_var) in
+  (let f := (fvar 1000 term_var) in
    let x := (fvar 999 term_var) in
-   (notype_tfix (close 0 (close 1 t 999) 1000))
+   (notype_tfix (close 0 (close 1 t 999) 1000)))
   (in custom expr at level 100, f ident, x ident, t custom expr, right associativity).
 
 
+
+Eval compute in [|
+     fun (x) => (fun (y) => ((x,y), fun(z) => (x, y))) |].
 
 Eval compute in [|
 (

--- a/Notations.v
+++ b/Notations.v
@@ -230,16 +230,19 @@ Notation "'size' ( t )" := (fun fv_id => (tsize (t fv_id))) (in custom expr,
 
 Notation "t '._1'" := (fun fv_id => (pi1 (t fv_id))) (in custom expr at level 200,
                                   t custom expr).
+
+
 Notation "t '._2'" := (fun fv_id => (pi2 (t fv_id))) (in custom expr at level 200,
                                   t custom expr).
 
 (* Booleans *)
-Notation "'true'" := (⤳ttrue) (in custom expr).
-Notation "'false'" := (⤳tfalse) (in custom expr).
+Notation "'t_true'" := (⤳ttrue) (in custom expr).
+Notation "'t_false'" := (⤳tfalse) (in custom expr).
 Notation "'if' c 'then' t 'else' f" := (fun fv_id => (ite (c fv_id) (t fv_id) (f fv_id))) (in custom expr at level 1,
                                                        c custom expr,
                                                        t custom expr,
                                                        f custom expr).
+
 
 (* Naturals *)
 Notation "'1'" := (⤳ (succ zero)) (in custom expr).
@@ -339,6 +342,7 @@ Notation "'match' t 'with' '|' 'left' l => t1 '|' 'right' r => t2 'end'" :=
 Eval compute in [| fun f x => x |].
 
 Eval compute in [| fun f x => fun g y => x |].
+
 
 
 

--- a/Tactics.v
+++ b/Tactics.v
@@ -296,3 +296,56 @@ Ltac force_invert P :=
   | H: ?F _ _ _ _ _ |- _ => unify F P; inversion H; clear H
   | H: ?F _ _ _ _ _ _ |- _ => unify F P; inversion H; clear H
   end.
+
+Hint Rewrite Bool.andb_true_iff: bools.
+Hint Rewrite Bool.andb_false_iff: bools.
+Hint Rewrite Bool.orb_true_iff: bools.
+Hint Rewrite Bool.orb_false_iff: bools.
+Hint Rewrite Bool.negb_true_iff: bools.
+Hint Rewrite Bool.negb_false_iff: bools.
+Ltac bools :=
+  autorewrite with bools in *.
+
+
+Ltac options :=
+unfold option_map in *.
+
+Ltac invert_constructor_equalities :=
+match goal with
+| H: ?F _ = ?F _ |- _ => is_constructor F; inversion H; clear H
+| H: ?F _ _ = ?F _ _ |- _ => is_constructor F; inversion H; clear H
+| H: ?F _ _ _ = ?F _ _ _ |- _ => is_constructor F; inversion H; clear H
+| H: ?F _ _ _ _ = ?F _ _ _ _ |- _ => is_constructor F; inversion H; clear H
+| H: ?F _ _ _ _ _ = ?F _ _ _ _ _ |- _ => is_constructor F; inversion H; clear H
+| H: ?F _ _ _ _ _ _ = ?F _ _ _ _ _ _ |- _ => is_constructor F; inversion H; clear H
+end.
+
+Ltac custom_light :=
+  (intros) ||
+  (subst).
+
+Ltac destruct_match :=
+match goal with
+| [ |- context[match ?t with _ => _ end]] =>
+let matched := fresh "matched" in
+destruct t eqn:matched
+| [ H: context[match ?t with _ => _ end] |- _ ] =>
+let matched := fresh "matched" in
+destruct t eqn:matched
+end.
+
+
+
+Ltac instantiate_eq_refl :=
+match goal with
+| H: _ |- _ => pose proof (proj1 (H _) eq_refl); clear H
+| H: _ |- _ => pose proof (proj2 (H _) eq_refl); clear H
+| H: _ |- _ => pose proof (H _ eq_refl); clear H
+| H: _ |- _ => pose proof (H _ _ eq_refl ); clear H
+| H: _ |- _ => pose proof (proj1 (H _ _ ) eq_refl); clear H
+| H: _ |- _ => pose proof (proj2 (H _ _ ) eq_refl); clear H
+| H: _ |- _ => pose proof (H _ _ _ eq_refl); clear H
+| H: _ |- _ => pose proof (H _ _ _ _ eq_refl); clear H
+| H: _ |- _ => pose proof (H _ _ _ _ _ eq_refl); clear H
+| H: _ |- _ => pose proof (H _ _ _ _ _ _ eq_refl); clear H
+end.

--- a/TypeErasure.v
+++ b/TypeErasure.v
@@ -16,6 +16,7 @@ Fixpoint erase_term (t: tree): tree :=
   | tsize t => tsize (erase_term t)
 
   | lambda T t' => notype_lambda (erase_term t')
+  | notype_lambda t => notype_lambda (erase_term t)
   | app t1 t2 => app (erase_term t1) (erase_term t2)
 
   | forall_inst t1 t2 => erase_term t1
@@ -44,6 +45,7 @@ Fixpoint erase_term (t: tree): tree :=
   | type_inst t T => erase_term t
 
   | tfix T t => notype_tfix (erase_term t)
+  | notype_tfix t => notype_tfix (erase_term t)
 
   | tfold T t' => erase_term t'
   | tunfold t' => erase_term t'

--- a/examples/ackermann.v
+++ b/examples/ackermann.v
@@ -4,7 +4,7 @@ Require Extraction.
 Import Notations.UnTyped.
 
 
-Definition ackermann_example := Eval compute in 
+Definition ackermann_example := Eval compute in
   [|
    let ackermann :=
        def_rec ack m n =>
@@ -15,7 +15,7 @@ Definition ackermann_example := Eval compute in
                 | s n' => ack m' (ack m n') end
        end
    in
-   ackermann 2 2        
+   ackermann 2 2
     |].
 
 
@@ -24,4 +24,4 @@ Eval compute in eval ackermann_example 1000.
 
 Extraction Language Ocaml.
 Set Extraction AccessOpaque.
-Extraction "ackermann.ml" ackermann_example eval. 
+Extraction "ackermann.ml" ackermann_example eval.

--- a/examples/ackermann.v
+++ b/examples/ackermann.v
@@ -1,0 +1,27 @@
+Require Export SystemFR.Notations.
+Require Export SystemFR.Evaluator.
+Require Extraction.
+Import Notations.UnTyped.
+
+
+Definition ackermann_example := Eval compute in 
+  [|
+   let ackermann :=
+       def_rec ack m n =>
+       match m with
+       | 0 => (s n)
+       | s m' => match n with
+                | 0 => ack m' 1
+                | s n' => ack m' (ack m n') end
+       end
+   in
+   ackermann 2 2        
+    |].
+
+
+Eval compute in eval ackermann_example 1000.
+
+
+Extraction Language Ocaml.
+Set Extraction AccessOpaque.
+Extraction "ackermann.ml" ackermann_example eval. 

--- a/examples/ackermann.v
+++ b/examples/ackermann.v
@@ -21,7 +21,11 @@ Definition ackermann_example := Eval compute in
 
 Eval compute in eval ackermann_example 1000.
 
+Example ackermann : (eval ackermann_example 1000) =  Some (succ (succ (succ (succ (succ (succ (succ zero))))))). (* 7 *)
+Proof.
+  native_compute; reflexivity. Qed.
 
+(* Extraction *)
 Extraction Language Ocaml.
 Set Extraction AccessOpaque.
 Extraction "ackermann.ml" ackermann_example eval.

--- a/examples/binaryStreams.v
+++ b/examples/binaryStreams.v
@@ -1,0 +1,64 @@
+Require Export SystemFR.Notations.
+Import Notations.UnTyped.
+Require Export SystemFR.Evaluator.
+Require Extraction.
+
+
+Definition streams_example := Eval compute in
+ [|
+
+
+  let nil := (left ()) in
+  let cons := fun x => fun xs => (right (x,xs)) in
+  let one := cons () nil in
+  let double := def_rec f l => match l with
+                              | left x => nil
+                              | right p => right ((), (right ((), (f (p._2))))) end
+  in
+  let power := def_rec f a b => match b with
+                               | left x => a
+                               | right p => f (double a) (p._2) end in
+
+  let getLast := def_rec f l => match l with
+                               | left x => nil
+                                            |right p => f (p._2) end in
+
+  getLast (power one (double (double (double (double one)))))|].
+
+
+Eval compute in (eval streams_example 30000).
+
+
+         (* Stream: a function that returns a pair (head, stream) *)
+
+ let constant := def_rec f x => (fun y => ((x, (f x)))) in
+ let head := (fun l => ((l ())._1)) in
+ let tail := (fun l => ((l ())._2)) in
+
+ let one := (fun l => (1, (constant 0)) in
+
+ let double := def_rec f stream y => (
+
+ let sum :=
+     def_rec f k stream =>
+     match k with
+     | 0 => 0
+     | s k' => let x := stream () in (
+                plus (x._1) (f k' (x._2))) end in
+ let take := def_rec f k stream => match k with
+                           | 0 => (head stream)
+                           | s k' => (f k' (tail stream))  end in
+ let zipwith := def_rec f app s1 => fun s2 => fun y => ((app (head s1) (head s2)), (f app (tail s1) (tail s2))) in
+ let fibonacci := def_rec f y => (1, (fun y => (1, (zipwith plus f (tail f))))) in
+
+ (take n fibonacci)  |].
+
+
+
+Fixpoint natToTreeNat (n: nat) := match n with
+                                 | 0 => zero
+                                 | S x => succ (natToTreeNat x) end.
+
+Extraction Language OCaml.
+Set Extraction AccessOpaque.
+Extraction "streams_example.ml" streams_example eval natToTreeNat.

--- a/examples/capturedVariable.v
+++ b/examples/capturedVariable.v
@@ -4,15 +4,15 @@ Require Extraction.
 Import Notations.UnTyped.
 
 
-Definition capturedVariable_example := Eval compute in 
-  [|    
+Definition capturedVariable_example := Eval compute in
+  [|
    let lt := def_rec f x y =>
              match x with
              | 0 => t_true
              | s x' => match y with
                       | 0 => t_false
                       | s y' => (f x' y') end end in
-   
+
    let x := 5 in
    let lessThanX := fun y => (lt y x) in
    let x := 3 in
@@ -21,9 +21,12 @@ Definition capturedVariable_example := Eval compute in
    |].
 
 
-Eval compute in eval capturedVariable_example 1000.
 
+Example capturedVariable : (eval capturedVariable_example 1000) =  Some (pp ttrue ttrue).
+Proof.
+  native_compute; reflexivity. Qed.
 
+(* Extraction *)
 Extraction Language Ocaml.
 Set Extraction AccessOpaque.
-Extraction "capturedVariable.ml" capturedVariable_example eval. 
+Extraction "capturedVariable.ml" capturedVariable_example eval.

--- a/examples/capturedVariable.v
+++ b/examples/capturedVariable.v
@@ -1,0 +1,29 @@
+Require Export SystemFR.Notations.
+Require Export SystemFR.Evaluator.
+Require Extraction.
+Import Notations.UnTyped.
+
+
+Definition capturedVariable_example := Eval compute in 
+  [|    
+   let lt := def_rec f x y =>
+             match x with
+             | 0 => t_true
+             | s x' => match y with
+                      | 0 => t_false
+                      | s y' => (f x' y') end end in
+   
+   let x := 5 in
+   let lessThanX := fun y => (lt y x) in
+   let x := 3 in
+   let y := 4 in
+   ((lessThanX x), (lessThanX y))
+   |].
+
+
+Eval compute in eval capturedVariable_example 1000.
+
+
+Extraction Language Ocaml.
+Set Extraction AccessOpaque.
+Extraction "capturedVariable.ml" capturedVariable_example eval. 

--- a/examples/capturedVariable2.ml
+++ b/examples/capturedVariable2.ml
@@ -1,0 +1,370 @@
+
+type bool =
+| True
+| False
+
+type nat =
+| O
+| S of nat
+
+type 'a option =
+| Some of 'a
+| None
+
+(** val option_map : ('a1 -> 'a2) -> 'a1 option -> 'a2 option **)
+
+let option_map f = function
+| Some a -> Some (f a)
+| None -> None
+
+type ('a, 'b) prod =
+| Pair of 'a * 'b
+
+type 'a sig0 = 'a
+  (* singleton inductive, whose constructor was exist *)
+
+type sumbool =
+| Left
+| Right
+
+(** val add : nat -> nat -> nat **)
+
+let rec add n m =
+  match n with
+  | O -> m
+  | S p -> S (add p m)
+
+module Nat =
+ struct
+  (** val eq_dec : nat -> nat -> sumbool **)
+
+  let rec eq_dec n m =
+    match n with
+    | O -> (match m with
+            | O -> Left
+            | S _ -> Right)
+    | S n0 -> (match m with
+               | O -> Right
+               | S m0 -> eq_dec n0 m0)
+ end
+
+type fv_tag =
+| Term_var
+| Type_var
+
+type tree =
+| Fvar of nat * fv_tag
+| Lvar of nat * fv_tag
+| T_nat
+| T_unit
+| T_bool
+| T_arrow of tree * tree
+| T_prod of tree * tree
+| T_sum of tree * tree
+| T_refine of tree * tree
+| T_type_refine of tree * tree
+| T_intersection of tree * tree
+| T_union of tree * tree
+| T_top
+| T_bot
+| T_equiv of tree * tree
+| T_forall of tree * tree
+| T_exists of tree * tree
+| T_abs of tree
+| T_rec of tree * tree * tree
+| Err of tree
+| Notype_err
+| Uu
+| Tsize of tree
+| Lambda of tree * tree
+| Notype_lambda of tree
+| App of tree * tree
+| Forall_inst of tree * tree
+| Pp of tree * tree
+| Pi1 of tree
+| Pi2 of tree
+| Because of tree * tree
+| Get_refinement_witness of tree * tree
+| Ttrue
+| Tfalse
+| Ite of tree * tree * tree
+| Boolean_recognizer of nat * tree
+| Zero
+| Succ of tree
+| Tmatch of tree * tree * tree
+| Tfix of tree * tree
+| Notype_tfix of tree
+| Tlet of tree * tree * tree
+| Notype_tlet of tree * tree
+| Type_abs of tree
+| Type_inst of tree * tree
+| Tfold of tree * tree
+| Tunfold of tree
+| Tunfold_in of tree * tree
+| Tunfold_pos_in of tree * tree
+| Tright of tree
+| Tleft of tree
+| Sum_match of tree * tree * tree
+| Typecheck of tree * tree
+| Trefl of tree * tree
+
+(** val build_nat : nat -> tree **)
+
+let rec build_nat = function
+| O -> Zero
+| S n0 -> Succ (build_nat n0)
+
+(** val open0 : nat -> tree -> tree -> tree **)
+
+let rec open0 k t rep =
+  match t with
+  | Lvar (i, f) -> (match f with
+                    | Term_var -> (match Nat.eq_dec k i with
+                                   | Left -> rep
+                                   | Right -> t)
+                    | Type_var -> t)
+  | T_arrow (t1, t2) -> T_arrow ((open0 k t1 rep), (open0 (S k) t2 rep))
+  | T_prod (t1, t2) -> T_prod ((open0 k t1 rep), (open0 (S k) t2 rep))
+  | T_sum (t1, t2) -> T_sum ((open0 k t1 rep), (open0 k t2 rep))
+  | T_refine (t0, p) -> T_refine ((open0 k t0 rep), (open0 (S k) p rep))
+  | T_type_refine (t1, t2) -> T_type_refine ((open0 k t1 rep), (open0 (S k) t2 rep))
+  | T_intersection (t1, t2) -> T_intersection ((open0 k t1 rep), (open0 k t2 rep))
+  | T_union (t1, t2) -> T_union ((open0 k t1 rep), (open0 k t2 rep))
+  | T_equiv (t1, t2) -> T_equiv ((open0 k t1 rep), (open0 k t2 rep))
+  | T_forall (t1, t2) -> T_forall ((open0 k t1 rep), (open0 (S k) t2 rep))
+  | T_exists (t1, t2) -> T_exists ((open0 k t1 rep), (open0 (S k) t2 rep))
+  | T_abs t0 -> T_abs (open0 k t0 rep)
+  | T_rec (n, t0, ts) -> T_rec ((open0 k n rep), (open0 k t0 rep), (open0 k ts rep))
+  | Err t0 -> Err (open0 k t0 rep)
+  | Tsize t0 -> Tsize (open0 k t0 rep)
+  | Lambda (t0, t') -> Lambda ((open0 k t0 rep), (open0 (S k) t' rep))
+  | Notype_lambda t' -> Notype_lambda (open0 (S k) t' rep)
+  | App (t1, t2) -> App ((open0 k t1 rep), (open0 k t2 rep))
+  | Forall_inst (t1, t2) -> Forall_inst ((open0 k t1 rep), (open0 k t2 rep))
+  | Pp (t1, t2) -> Pp ((open0 k t1 rep), (open0 k t2 rep))
+  | Pi1 t0 -> Pi1 (open0 k t0 rep)
+  | Pi2 t0 -> Pi2 (open0 k t0 rep)
+  | Because (t1, t2) -> Because ((open0 k t1 rep), (open0 k t2 rep))
+  | Get_refinement_witness (t1, t2) -> Get_refinement_witness ((open0 k t1 rep), (open0 (S k) t2 rep))
+  | Ite (t1, t2, t3) -> Ite ((open0 k t1 rep), (open0 k t2 rep), (open0 k t3 rep))
+  | Boolean_recognizer (r, t0) -> Boolean_recognizer (r, (open0 k t0 rep))
+  | Succ t' -> Succ (open0 k t' rep)
+  | Tmatch (t', t1, t2) -> Tmatch ((open0 k t' rep), (open0 k t1 rep), (open0 (S k) t2 rep))
+  | Tfix (t0, t') -> Tfix ((open0 (S k) t0 rep), (open0 (S (S k)) t' rep))
+  | Notype_tfix t' -> Notype_tfix (open0 (S (S k)) t' rep)
+  | Tlet (t1, t0, t2) -> Tlet ((open0 k t1 rep), (open0 k t0 rep), (open0 (S k) t2 rep))
+  | Notype_tlet (t1, t2) -> Notype_tlet ((open0 k t1 rep), (open0 (S k) t2 rep))
+  | Type_abs t0 -> Type_abs (open0 k t0 rep)
+  | Type_inst (t0, t1) -> Type_inst ((open0 k t0 rep), (open0 k t1 rep))
+  | Tfold (t0, t') -> Tfold ((open0 k t0 rep), (open0 k t' rep))
+  | Tunfold t' -> Tunfold (open0 k t' rep)
+  | Tunfold_in (t1, t2) -> Tunfold_in ((open0 k t1 rep), (open0 (S k) t2 rep))
+  | Tunfold_pos_in (t1, t2) -> Tunfold_pos_in ((open0 k t1 rep), (open0 (S k) t2 rep))
+  | Tright t' -> Tright (open0 k t' rep)
+  | Tleft t' -> Tleft (open0 k t' rep)
+  | Sum_match (t', tl, tr) -> Sum_match ((open0 k t' rep), (open0 (S k) tl rep), (open0 (S k) tr rep))
+  | Typecheck (t0, t1) -> Typecheck ((open0 k t0 rep), (open0 k t1 rep))
+  | Trefl (t1, t2) -> Trefl ((open0 k t1 rep), (open0 k t2 rep))
+  | _ -> t
+
+(** val erase_term : tree -> tree **)
+
+let rec erase_term t = match t with
+| Fvar (_, f) -> (match f with
+                  | Term_var -> t
+                  | Type_var -> Uu)
+| Lvar (_, f) -> (match f with
+                  | Term_var -> t
+                  | Type_var -> Uu)
+| Err _ -> Notype_err
+| Tsize t0 -> Tsize (erase_term t0)
+| Lambda (_, t') -> Notype_lambda (erase_term t')
+| Notype_lambda t0 -> Notype_lambda (erase_term t0)
+| App (t1, t2) -> App ((erase_term t1), (erase_term t2))
+| Forall_inst (t1, _) -> erase_term t1
+| Pp (t1, t2) -> Pp ((erase_term t1), (erase_term t2))
+| Pi1 t' -> Pi1 (erase_term t')
+| Pi2 t' -> Pi2 (erase_term t')
+| Because (t1, _) -> erase_term t1
+| Get_refinement_witness (_, t2) -> App ((Notype_lambda (erase_term t2)), Uu)
+| Ttrue -> Ttrue
+| Tfalse -> Tfalse
+| Ite (t1, t2, t3) -> Ite ((erase_term t1), (erase_term t2), (erase_term t3))
+| Boolean_recognizer (r, t0) -> Boolean_recognizer (r, (erase_term t0))
+| Zero -> Zero
+| Succ t' -> Succ (erase_term t')
+| Tmatch (t', t0, ts) -> Tmatch ((erase_term t'), (erase_term t0), (erase_term ts))
+| Tfix (_, t0) -> Notype_tfix (erase_term t0)
+| Notype_tfix t0 -> Notype_tfix (erase_term t0)
+| Tlet (t1, _, t2) -> App ((Notype_lambda (erase_term t2)), (erase_term t1))
+| Notype_tlet (t1, t2) -> App ((Notype_lambda (erase_term t2)), (erase_term t1))
+| Type_abs t0 -> erase_term t0
+| Type_inst (t0, _) -> erase_term t0
+| Tfold (_, t') -> erase_term t'
+| Tunfold t' -> erase_term t'
+| Tunfold_in (t1, t2) -> App ((Notype_lambda (erase_term t2)), (erase_term t1))
+| Tunfold_pos_in (t1, t2) -> App ((Notype_lambda (erase_term t2)), (erase_term t1))
+| Tright t' -> Tright (erase_term t')
+| Tleft t' -> Tleft (erase_term t')
+| Sum_match (t', tl, tr) -> Sum_match ((erase_term t'), (erase_term tl), (erase_term tr))
+| Typecheck (t0, _) -> erase_term t0
+| _ -> Uu
+
+(** val tsize_semantics : tree -> nat **)
+
+let rec tsize_semantics = function
+| Pp (t1, t2) -> add (add (S O) (tsize_semantics t1)) (tsize_semantics t2)
+| Succ t' -> add (S O) (tsize_semantics t')
+| Tright t0 -> add (S O) (tsize_semantics t0)
+| Tleft t0 -> add (S O) (tsize_semantics t0)
+| _ -> O
+
+(** val is_pair : tree -> tree **)
+
+let is_pair = function
+| Pp (_, _) -> Ttrue
+| _ -> Tfalse
+
+(** val is_succ : tree -> tree **)
+
+let is_succ = function
+| Succ _ -> Ttrue
+| _ -> Tfalse
+
+(** val is_lambda : tree -> tree **)
+
+let is_lambda = function
+| Notype_lambda _ -> Ttrue
+| _ -> Tfalse
+
+(** val isValue : tree -> bool **)
+
+let rec isValue = function
+| Uu -> True
+| Notype_lambda _ -> True
+| Pp (e1, e2) -> (match isValue e1 with
+                  | True -> isValue e2
+                  | False -> False)
+| Ttrue -> True
+| Tfalse -> True
+| Zero -> True
+| Succ e1 -> isValue e1
+| Tright e1 -> isValue e1
+| Tleft e1 -> isValue e1
+| _ -> False
+
+(** val getPair : tree -> (tree, tree) prod option **)
+
+let getPair = function
+| Pp (e1, e2) -> Some (Pair (e1, e2))
+| _ -> None
+
+(** val getApp : tree -> tree option **)
+
+let getApp = function
+| Notype_lambda body -> Some body
+| _ -> None
+
+(** val ss_eval : tree -> tree option **)
+
+let rec ss_eval = function
+| Tsize t0 ->
+  (match isValue t0 with
+   | True -> Some (build_nat (tsize_semantics t0))
+   | False -> option_map (fun x -> Tsize x) (ss_eval t0))
+| App (t1, t2) ->
+  (match isValue t1 with
+   | True ->
+     (match getApp t1 with
+      | Some ts ->
+        (match isValue t2 with
+         | True -> Some (open0 O ts t2)
+         | False -> option_map (fun x -> App (t1, x)) (ss_eval t2))
+      | None -> option_map (fun x -> App (t1, x)) (ss_eval t2))
+   | False -> option_map (fun e -> App (e, t2)) (ss_eval t1))
+| Pp (e1, e2) ->
+  (match isValue e1 with
+   | True -> option_map (fun x -> Pp (e1, x)) (ss_eval e2)
+   | False -> option_map (fun e -> Pp (e, e2)) (ss_eval e1))
+| Pi1 t0 ->
+  (match getPair t0 with
+   | Some p ->
+     let Pair (e1, e2) = p in
+     (match match isValue e1 with
+            | True -> isValue e2
+            | False -> False with
+      | True -> Some e1
+      | False -> option_map (fun x -> Pi1 x) (ss_eval t0))
+   | None -> option_map (fun x -> Pi1 x) (ss_eval t0))
+| Pi2 t0 ->
+  (match getPair t0 with
+   | Some p ->
+     let Pair (e1, e2) = p in
+     (match match isValue e1 with
+            | True -> isValue e2
+            | False -> False with
+      | True -> Some e2
+      | False -> option_map (fun x -> Pi2 x) (ss_eval t0))
+   | None -> option_map (fun x -> Pi2 x) (ss_eval t0))
+| Ite (t0, t1, t2) ->
+  (match t0 with
+   | Ttrue -> Some t1
+   | Tfalse -> Some t2
+   | _ -> option_map (fun e -> Ite (e, t1, t2)) (ss_eval t0))
+| Boolean_recognizer (r, t0) ->
+  (match isValue t0 with
+   | True ->
+     (match r with
+      | O -> Some (is_pair t0)
+      | S n ->
+        (match n with
+         | O -> Some (is_succ t0)
+         | S n0 -> (match n0 with
+                    | O -> Some (is_lambda t0)
+                    | S _ -> None)))
+   | False -> option_map (fun x -> Boolean_recognizer (r, x)) (ss_eval t0))
+| Succ t0 -> option_map (fun x -> Succ x) (ss_eval t0)
+| Tmatch (t1, t0, ts) ->
+  (match t1 with
+   | Zero -> Some t0
+   | Succ t2 ->
+     (match isValue t2 with
+      | True -> Some (open0 O ts t2)
+      | False -> option_map (fun e -> Tmatch (e, t0, ts)) (ss_eval t1))
+   | _ -> option_map (fun e -> Tmatch (e, t0, ts)) (ss_eval t1))
+| Notype_tfix ts -> Some (open0 O (open0 (S O) ts Zero) (Notype_tfix ts))
+| Tright t0 -> option_map (fun x -> Tright x) (ss_eval t0)
+| Tleft t0 -> option_map (fun x -> Tleft x) (ss_eval t0)
+| Sum_match (t0, tl, tr) ->
+  (match isValue t0 with
+   | True -> (match t0 with
+              | Tright v -> Some (open0 O tr v)
+              | Tleft v -> Some (open0 O tl v)
+              | _ -> None)
+   | False -> option_map (fun e -> Sum_match (e, tl, tr)) (ss_eval t0))
+| _ -> None
+
+(** val ss_eval_n : tree -> nat -> tree option **)
+
+let rec ss_eval_n t = function
+| O -> Some t
+| S k' -> (match ss_eval t with
+           | Some t' -> ss_eval_n t' k'
+           | None -> Some t)
+
+(** val eval : tree -> nat -> tree option **)
+
+let eval t k =
+  ss_eval_n (erase_term t) k
+
+(** val capturedVariable2_example : tree **)
+
+let capturedVariable2_example =
+  Notype_tlet ((Notype_tfix (Notype_lambda (Notype_lambda (Tmatch ((Lvar (O, Term_var)), (Lvar ((S O), Term_var)),
+    (Tmatch ((Lvar ((S (S O)), Term_var)), Zero, (App ((App ((Lvar ((S (S (S (S O)))), Term_var)), (Lvar (O,
+    Term_var)))), (Lvar ((S O), Term_var))))))))))), (Notype_tlet ((Notype_tfix (Notype_lambda (Tmatch ((Lvar (O,
+    Term_var)), Zero, (Succ (Succ (App ((Lvar ((S (S O)), Term_var)), (Lvar (O, Term_var)))))))))), (Notype_tlet
+    ((Notype_tlet ((Succ (Succ (Succ (Succ (Succ Zero))))), (Notype_tlet ((Notype_lambda (App ((Lvar ((S (S O)),
+    Term_var)), (Lvar (O, Term_var))))), (Notype_tlet ((App ((Lvar (O, Term_var)), (Lvar ((S O), Term_var)))),
+    (App ((App ((Lvar ((S (S (S (S O)))), Term_var)), (Lvar (O, Term_var)))), (Lvar (O, Term_var)))))))))), (Lvar
+    (O, Term_var)))))))

--- a/examples/capturedVariable2.v
+++ b/examples/capturedVariable2.v
@@ -1,0 +1,34 @@
+Require Export SystemFR.Notations.
+Require Export SystemFR.Evaluator.
+Require Extraction.
+Import Notations.UnTyped.
+
+
+Definition capturedVariable2_example := Eval compute in 
+   [|
+    let minus := def_rec f x y => match y with
+                                 | 0 => x
+                                 |s y' => match x with
+                                         | 0 => 0
+                                         | s x' => (f x' y') end
+                                 end
+    in
+    let double := def_rec f x => match x with
+                                | 0 => 0
+                                | s x' => (s (s (f x'))) end
+    in
+    let x := (
+         let x := 5 in
+         let f := fun x => (double x) in
+         let x := (f x) in
+         minus x x) in
+    x
+    |].
+
+
+Eval compute in eval capturedVariable2_example 1000.
+
+
+Extraction Language Ocaml.
+Set Extraction AccessOpaque.
+Extraction "capturedVariable2.ml" capturedVariable2_example eval. 

--- a/examples/capturedVariable2.v
+++ b/examples/capturedVariable2.v
@@ -4,7 +4,7 @@ Require Extraction.
 Import Notations.UnTyped.
 
 
-Definition capturedVariable2_example := Eval compute in 
+Definition capturedVariable2_example := Eval compute in
    [|
     let minus := def_rec f x y => match y with
                                  | 0 => x
@@ -26,9 +26,12 @@ Definition capturedVariable2_example := Eval compute in
     |].
 
 
-Eval compute in eval capturedVariable2_example 1000.
 
+Example capturedVariable2 : (eval capturedVariable2_example 1000) =  Some zero.
+Proof.
+  native_compute ; reflexivity. Qed.
 
+(* Extraction *)
 Extraction Language Ocaml.
 Set Extraction AccessOpaque.
-Extraction "capturedVariable2.ml" capturedVariable2_example eval. 
+Extraction "capturedVariable2.ml" capturedVariable2_example eval.

--- a/examples/fact.v
+++ b/examples/fact.v
@@ -4,7 +4,7 @@ Require Extraction.
 Import Notations.UnTyped.
 
 
-Definition fact_example := Eval compute in 
+Definition fact_example := Eval compute in
   [|
    let plus :=
        def_rec plus x y =>
@@ -35,9 +35,11 @@ Fixpoint treeToNat (t: tree) :=
   end.
 
 
-Eval compute in option_map treeToNat (eval fact_example 30000).
+Example fact : (option_map treeToNat (eval fact_example 30000)) = Some 5040.
+Proof.
+  native_compute. reflexivity. Qed.
 
-
+(* Extraction *)
 Extraction Language Ocaml.
 Set Extraction AccessOpaque.
-Extraction "fact.ml" fact_example eval. 
+Extraction "fact.ml" fact_example eval.

--- a/examples/fact.v
+++ b/examples/fact.v
@@ -1,0 +1,43 @@
+Require Export SystemFR.Notations.
+Require Export SystemFR.Evaluator.
+Require Extraction.
+Import Notations.UnTyped.
+
+
+Definition fact_example := Eval compute in 
+  [|
+   let plus :=
+       def_rec plus x y =>
+       match x with
+       | 0 => y
+       | s x' => s (plus x' y) end
+   in
+   let mult :=
+       def_rec mult x y =>
+       match x with
+       | 0 => 0
+       | s x' => plus y (mult x' y) end
+   in
+   let fact :=
+       def_rec fact n =>
+       match n with
+       | 0 => 1
+       | s n' => mult n (fact n') end
+   in
+   fact 7
+    |].
+
+Fixpoint treeToNat (t: tree) :=
+  match t with
+  | zero => 0
+  | succ t' => S (treeToNat t')
+  | _ => 0
+  end.
+
+
+Eval compute in option_map treeToNat (eval fact_example 30000).
+
+
+Extraction Language Ocaml.
+Set Extraction AccessOpaque.
+Extraction "fact.ml" fact_example eval. 

--- a/examples/isEven.v
+++ b/examples/isEven.v
@@ -1,0 +1,34 @@
+Require Export SystemFR.Notations.
+Require Export SystemFR.Evaluator.
+Require Extraction.
+Import Notations.UnTyped.
+
+
+Definition natEq_example := Eval compute in 
+  [|
+   let natEq := (
+         def_rec nat_eq x y =>
+         match x with
+         | 0 => match y with
+               | 0 => t_true
+               | s y' => t_false end
+         | s x' =>
+           match y with
+           | 0 =>  t_false
+           | s y' => (nat_eq x' y')
+           end
+         end) in
+   natEq 0 (s 0) |].
+
+
+Print natEq_example.
+
+
+Extraction Language Ocaml.
+Set Extraction AccessOpaque.
+
+Definition result := (eval natEq_example 1000).
+Extraction "isEven.ml" result. (* Fails with : Fetching opaque proofs from disk for SystemFR.Evaluator
+Error: The value you are asking for (getApp) is not available in this process. If you really need this, pass the
+"-async-proofs off" option to CoqIDE to disable asynchronous script processing and don't pass "-quick" to coqc *)
+

--- a/examples/isEven.v
+++ b/examples/isEven.v
@@ -4,7 +4,7 @@ Require Extraction.
 Import Notations.UnTyped.
 
 
-Definition natEq_example := Eval compute in 
+Definition natEq_example := Eval compute in
   [|
    let natEq := (
          def_rec f x y =>
@@ -51,9 +51,15 @@ Definition natEq_example := Eval compute in
 
 Print natEq_example.
 
+Example isEven: (eval natEq_example 10000) = Some ttrue.
+Proof.
+  native_compute.
+  reflexivity. Qed.
 
+
+(* Extraction *)
 Extraction Language Ocaml.
 Set Extraction AccessOpaque.
 
 Definition isEven := natEq_example.
-Extraction "isEven.ml" isEven eval. 
+Extraction "isEven.ml" isEven eval.

--- a/examples/isEven.v
+++ b/examples/isEven.v
@@ -55,6 +55,5 @@ Print natEq_example.
 Extraction Language Ocaml.
 Set Extraction AccessOpaque.
 
-Definition result := (eval natEq_example 1000).
-Eval compute in result.
-Extraction "isEven.ml" result eval. 
+Definition isEven := natEq_example.
+Extraction "isEven.ml" isEven eval. 

--- a/examples/isEven.v
+++ b/examples/isEven.v
@@ -7,16 +7,16 @@ Import Notations.UnTyped.
 Definition natEq_example := Eval compute in 
   [|
    let natEq := (
-         def_rec nat_eq x y =>
+         def_rec f x y =>
          match x with
-         | 0 => match y with
+         | 0 => (match y with
                | 0 => t_true
-               | s y' => t_false end
-         | s x' =>
+               | s y' => t_false end)
+         | s x' =>(
            match y with
            | 0 =>  t_false
-           | s y' => (nat_eq x' y')
-           end
+           | s y' => (f x' y')
+           end)
          end) in
    natEq 0 (s 0) |].
 
@@ -28,7 +28,8 @@ Extraction Language Ocaml.
 Set Extraction AccessOpaque.
 
 Definition result := (eval natEq_example 1000).
-Extraction "isEven.ml" result. (* Fails with : Fetching opaque proofs from disk for SystemFR.Evaluator
-Error: The value you are asking for (getApp) is not available in this process. If you really need this, pass the
-"-async-proofs off" option to CoqIDE to disable asynchronous script processing and don't pass "-quick" to coqc *)
+Extraction "isEven.ml" result eval. 
 
+Definition ex1 :=[| let f := def_rec f x => (s x) in f (f (f 0)) |]. 
+Eval compute in ex1.
+Eval compute in eval ex1 10.

--- a/examples/isEven.v
+++ b/examples/isEven.v
@@ -18,7 +18,35 @@ Definition natEq_example := Eval compute in
            | s y' => (f x' y')
            end)
          end) in
-   natEq 0 (s 0) |].
+   let boolAnd := (fun a => fun b => if (a) then b else t_false) in
+   let oddEven := def_rec f p x => match p with
+                                 | 0 => match x with
+                                       | 0 => t_true
+                                       | s x' => f 1 x' end
+                                 | s p' => match x with
+                                          | 0 => t_false
+                                          | s x' => f 0 x'
+                                          end
+                                 end
+   in
+   let oddEven1 := def_rec f x => (
+                     (match x with | 0 => t_true  | s x' => ((f x')._2) end),
+                     (match x with | 0 => t_false | s x' => ((f x')._1) end)
+                   ) in
+   let isEven := oddEven 0 in
+   let isOdd := oddEven 1 in
+   let isEven1 := (fun x => ((oddEven1 x)._1)) in
+   let isOdd1 := (fun x => ((oddEven1 x)._2)) in
+
+   boolAnd (isEven 0)
+           (boolAnd (isEven1 0)
+                    (boolAnd (isOdd 1)
+                             (boolAnd (isOdd1 1)
+                                      (boolAnd (isEven 2)
+                                               (boolAnd (isEven1 2)
+                                                        (boolAnd (isOdd 3)
+                                                                 (isOdd1 3)))))))
+    |].
 
 
 Print natEq_example.
@@ -28,8 +56,5 @@ Extraction Language Ocaml.
 Set Extraction AccessOpaque.
 
 Definition result := (eval natEq_example 1000).
+Eval compute in result.
 Extraction "isEven.ml" result eval. 
-
-Definition ex1 :=[| let f := def_rec f x => (s x) in f (f (f 0)) |]. 
-Eval compute in ex1.
-Eval compute in eval ex1 10.

--- a/examples/list_perf.v
+++ b/examples/list_perf.v
@@ -22,28 +22,24 @@ Definition lists := Eval compute in
   let ten := cons () nine in
   let double := def_rec f l => match l with
                               | left x => nil
-                              | right p => right ((), (right ((), (f (p._2))))) end
-  in
+                              | right p => right ((), (right ((), (f (p._2))))) end in
   let power := def_rec f a b => match b with
                                | left x => a
                                | right p => f (double a) (p._2) end in
   let getLast := def_rec f l => match l with
                                | left x => ()
-                                            |right p => f (p._2) end in
+                               |right p => f (p._2) end in
+  getLast (power ten ten)
 
-  getLast (power six eight)|].
-(*
- power a b = a*2^b
- *)
-Fixpoint getNat (t:tree) :=
-  match t with
-  | tright (pp t1 t2) => S (getNat t2)
-  | _ => 0 end.
+|].
+
+(* power a b = a*2^b *)
 
 
-Example example1 : (eval lists 20000) = Some (uu).
+Example example1 : (eval lists 1000000) = Some (uu).
 Proof.
   Set Ltac Profiling.
+  native_compute.
   reflexivity.
   Show Ltac Profile.
   Qed.

--- a/examples/list_perf.v
+++ b/examples/list_perf.v
@@ -1,0 +1,55 @@
+Require Export SystemFR.Notations.
+Import Notations.UnTyped.
+Require Export SystemFR.Evaluator.
+Require Extraction.
+
+
+Definition lists := Eval compute in
+ [|
+
+
+  let nil := (left ()) in
+  let cons := fun x => fun xs => (right (x,xs)) in
+  let one := cons () nil in
+  let two := cons () one in
+  let three := cons () two in
+  let four := cons () three in
+  let five := cons () four in
+  let six := cons () five in
+  let seven := cons () six in
+  let eight := cons () seven in
+  let nine := cons () eight in
+  let ten := cons () nine in
+  let double := def_rec f l => match l with
+                              | left x => nil
+                              | right p => right ((), (right ((), (f (p._2))))) end
+  in
+  let power := def_rec f a b => match b with
+                               | left x => a
+                               | right p => f (double a) (p._2) end in
+  let getLast := def_rec f l => match l with
+                               | left x => ()
+                                            |right p => f (p._2) end in
+
+  getLast (power six eight)|].
+(*
+ power a b = a*2^b
+ *)
+Fixpoint getNat (t:tree) :=
+  match t with
+  | tright (pp t1 t2) => S (getNat t2)
+  | _ => 0 end.
+
+
+Example example1 : (eval lists 20000) = Some (uu).
+Proof.
+  Set Ltac Profiling.
+  reflexivity.
+  Show Ltac Profile.
+  Qed.
+
+
+
+Extraction Language OCaml.
+Set Extraction AccessOpaque.
+Extraction "list_perf.ml" lists eval.

--- a/examples/natmatch.v
+++ b/examples/natmatch.v
@@ -1,0 +1,25 @@
+Require Export SystemFR.Notations.
+Require Export SystemFR.Evaluator.
+Require Extraction.
+Import Notations.UnTyped.
+
+
+Definition natmatch_example := Eval compute in 
+  [|
+   let pred :=
+       def_rec ack m =>
+       match m with
+       | 0 => 0
+       | s m' => m'
+       end
+   in
+   pred 9      
+    |].
+
+
+Eval compute in eval natmatch_example 1000.
+
+
+Extraction Language Ocaml.
+Set Extraction AccessOpaque.
+Extraction "natmatch.ml" natmatch_example eval. 

--- a/examples/natmatch.v
+++ b/examples/natmatch.v
@@ -4,7 +4,7 @@ Require Extraction.
 Import Notations.UnTyped.
 
 
-Definition natmatch_example := Eval compute in 
+Definition natmatch_example := Eval compute in
   [|
    let pred :=
        def_rec ack m =>
@@ -13,13 +13,15 @@ Definition natmatch_example := Eval compute in
        | s m' => m'
        end
    in
-   pred 9      
+   pred 9
     |].
 
 
-Eval compute in eval natmatch_example 1000.
+Example natmatch : (eval natmatch_example 1000) =  Some [| 8 |].
+Proof.
+  native_compute; reflexivity. Qed.
 
-
+(* Extraction *)
 Extraction Language Ocaml.
 Set Extraction AccessOpaque.
-Extraction "natmatch.ml" natmatch_example eval. 
+Extraction "natmatch.ml" natmatch_example eval.

--- a/examples/streams.v
+++ b/examples/streams.v
@@ -1,9 +1,11 @@
 Require Export SystemFR.Notations.
 Import Notations.UnTyped.
+Require Export SystemFR.Evaluator.
+Require Extraction.
 
 
 Definition streams_example := Eval compute in 
-      [|
+  fun n => [|
  let eq_nat := (
          def_rec f x y =>
          match x with
@@ -20,35 +22,32 @@ Definition streams_example := Eval compute in
        def_rec f x y =>
        match x with
        | 0 => y
-       |s x' => f x' y end)
- in
-        
- let nil  := left () in
- let cons := fun x => fun xs => right ((x,xs)) in
- let head := fun l => (l ())._1 in
- let tail := fun l => (l ())._2 in
- let constant := def_rec f x => (fun y => right ((x, (f x) ()))) in 
- let sum := def_rec f k stream => match k with
-                                 | 0 => 0
-                                 | s k' => let x := stream () in (
-                                      plus x._1 (f k' x._2)) end in
-
- let map := def_rec f g stream => fun y => (g (head stream), f g (tail stream)) in
- let zipwith := def_rec f app s1 => fun s2 => fun y => ((app (head s1) (head s2)), (f (tail s1) (tail s2))) in
+       | s x' => s (f x' y) end) in
+         
+ (* Stream: a function that returns a pair (head, stream) *)
+ let constant := def_rec f x => (fun y => ((x, (f x)))) in
+ let head := (fun l => ((l ())._1)) in
+ let tail := (fun l => ((l ())._2)) in
+ let sum :=
+     def_rec f k stream =>
+     match k with
+     | 0 => 0
+     | s k' => let x := stream () in (
+                plus (x._1) (f k' (x._2))) end in
  let take := def_rec f k stream => match k with
-                           | 0 => nil
-                                   | s k' => cons (head stream) (f k' (tail stream)) end in 
- let fibonacci := def_rec f y => (0, fun y => (1, zipwith plus f (tail f)))
-                                  in take 0 fibonacci |].
-Print streams_example.
+                           | 0 => (head stream)
+                           | s k' => (f k' (tail stream))  end in 
+ let zipwith := def_rec f app s1 => fun s2 => fun y => ((app (head s1) (head s2)), (f app (tail s1) (tail s2))) in
+ let fibonacci := def_rec f y => (1, (fun y => (1, (zipwith plus f (tail f))))) in 
+
+ (take n fibonacci)  |].
 
 
-Require Export SystemFR.Evaluator.
 
-
-Require Extraction.
+Fixpoint natToTreeNat (n: nat) := match n with
+                                 | 0 => zero
+                                 | S x => succ (natToTreeNat x) end.
 
 Extraction Language OCaml.
-(* Set Extraction AccessOpaque.*)
-
-Extraction "streams_example.ml" streams_example eval.
+Set Extraction AccessOpaque.
+Extraction "streams_example.ml" streams_example eval natToTreeNat.

--- a/examples/streams.v
+++ b/examples/streams.v
@@ -1,0 +1,54 @@
+Require Export SystemFR.Notations.
+Import Notations.UnTyped.
+
+
+Definition streams_example := Eval compute in 
+      [|
+ let eq_nat := (
+         def_rec f x y =>
+         match x with
+         | 0 => match y with
+               | 0 => t_true
+               | s y' => t_false end
+         | s x' =>
+           match y with
+           | 0 =>  t_false
+           | s y' => (f x' y')
+           end
+         end) in
+ let plus := (
+       def_rec f x y =>
+       match x with
+       | 0 => y
+       |s x' => f x' y end)
+ in
+        
+ let nil  := left () in
+ let cons := fun x => fun xs => right ((x,xs)) in
+ let head := fun l => (l ())._1 in
+ let tail := fun l => (l ())._2 in
+ let constant := def_rec f x => (fun y => right ((x, (f x) ()))) in 
+ let sum := def_rec f k stream => match k with
+                                 | 0 => 0
+                                 | s k' => let x := stream () in (
+                                      plus x._1 (f k' x._2)) end in
+
+ let map := def_rec f g stream => fun y => (g (head stream), f g (tail stream)) in
+ let zipwith := def_rec f app s1 => fun s2 => fun y => ((app (head s1) (head s2)), (f (tail s1) (tail s2))) in
+ let take := def_rec f k stream => match k with
+                           | 0 => nil
+                                   | s k' => cons (head stream) (f k' (tail stream)) end in 
+ let fibonacci := def_rec f y => (0, fun y => (1, zipwith plus f (tail f)))
+                                  in take 0 fibonacci |].
+Print streams_example.
+
+
+Require Export SystemFR.Evaluator.
+
+
+Require Extraction.
+
+Extraction Language OCaml.
+(* Set Extraction AccessOpaque.*)
+
+Extraction "streams_example.ml" streams_example eval.

--- a/examples/streams_perf.v
+++ b/examples/streams_perf.v
@@ -1,0 +1,69 @@
+Require Export SystemFR.Notations.
+Import Notations.UnTyped.
+Require Export SystemFR.Evaluator.
+Require Extraction.
+
+
+Definition streams := Eval compute in
+ [|
+
+  let head := fun stream => ((stream ())._1) in
+  let tail := fun stream => ((stream ())._2) in
+  let before := fun val => fun stream => fun y => (val, stream) in
+  let constant := def_rec f x y => (x, (f x)) in
+
+  let zero := (constant t_false) in
+  let one := before t_true zero in
+  let two := before t_true one in
+  let three := before t_true two in
+  let four := before t_true three in
+  let five := before t_true four in
+  let six := before t_true five in
+  let seven := before t_true six in
+  let eight := before t_true seven in
+
+  let double := def_rec f st y => (
+                  let head := (st ()) in
+                  if (head._1) then
+                    (t_true,(before t_true (f (head._2))))
+                  else
+                    (t_false, st)
+                ) in
+  let power := def_rec f st1 st2 => (fun y => (
+                 let head := (st2 ()) in
+                 if (head._1) then
+                   (f (double st1) (head._2))
+                 else
+                   st1 () )) in
+
+  let count := def_rec f st => (
+                 let head := (st ()) in
+                 if (head._1) then s (f (head._2)) else 0) in
+  let getLast := def_rec f st => (
+                   let head := (st ()) in
+                   if (head._1) then (f (head._2)) else ()) in
+  (getLast (power eight eight))
+  |].
+
+
+Fixpoint getNat (t:tree) :=
+  match t with
+  | succ t2 => S (getNat t2)
+  | _ => 0 end.
+
+
+(* Eval compute in option_map getNat (eval streams 10000).*)
+(* Eval compute in (eval streams 20000). *)
+
+Example example1 : (eval streams 40000) = Some (uu).
+Proof.
+  Set Ltac Profiling.
+  reflexivity.
+  Show Ltac Profile.
+  Qed.
+(* 21.285s *)
+
+
+Extraction Language OCaml.
+Set Extraction AccessOpaque.
+Extraction "streams_perf.ml" streams eval.

--- a/examples/streams_perf.v
+++ b/examples/streams_perf.v
@@ -21,6 +21,7 @@ Definition streams := Eval compute in
   let six := before t_true five in
   let seven := before t_true six in
   let eight := before t_true seven in
+  let nine := before t_true eight in
 
   let double := def_rec f st y => (
                   let head := (st ()) in
@@ -42,28 +43,23 @@ Definition streams := Eval compute in
   let getLast := def_rec f st => (
                    let head := (st ()) in
                    if (head._1) then (f (head._2)) else ()) in
-  (getLast (power eight eight))
+  (getLast (power seven seven))
   |].
 
 
-Fixpoint getNat (t:tree) :=
-  match t with
-  | succ t2 => S (getNat t2)
-  | _ => 0 end.
+Eval native_compute in (eval streams 20000).
 
 
-(* Eval compute in option_map getNat (eval streams 10000).*)
-(* Eval compute in (eval streams 20000). *)
-
-Example example1 : (eval streams 40000) = Some (uu).
+Example example1 : (eval streams 100000) = Some (uu).
 Proof.
   Set Ltac Profiling.
-  reflexivity.
+  native_compute.
   Show Ltac Profile.
+  reflexivity.
   Qed.
-(* 21.285s *)
 
 
+(* Extraction *)
 Extraction Language OCaml.
 Set Extraction AccessOpaque.
 Extraction "streams_perf.ml" streams eval.

--- a/examples/sumAcc.v
+++ b/examples/sumAcc.v
@@ -1,0 +1,34 @@
+Require Export SystemFR.Notations.
+Require Export SystemFR.Evaluator.
+Require Extraction.
+Import Notations.UnTyped.
+
+
+Fixpoint natToTreeNat (n: nat) := match n with
+                                 | 0 => zero
+                                 | S x => succ (natToTreeNat x) end.
+
+Definition sumAcc_example := Eval compute in 
+  [|
+   let plus := (
+       def_rec f x y =>
+       match x with
+       | 0 => y
+       | s x' => s (f x' y) end) in
+   let sumAcc := def_rec f acc v => match v with
+                                   | left x => acc
+                                   | right x => f (plus x acc) end
+   in
+   let sum := sumAcc 0 in
+   sumAcc 0 (right 5) (right 2) (left ())
+    |].
+
+
+Eval compute in eval sumAcc_example 1000.
+
+
+Extraction Language Ocaml.
+Set Extraction AccessOpaque.
+Extraction "sumAcc.ml" sumAcc_example eval. 
+
+

--- a/examples/sumAcc.v
+++ b/examples/sumAcc.v
@@ -8,7 +8,7 @@ Fixpoint natToTreeNat (n: nat) := match n with
                                  | 0 => zero
                                  | S x => succ (natToTreeNat x) end.
 
-Definition sumAcc_example := Eval compute in 
+Definition sumAcc_example := Eval compute in
   [|
    let plus := (
        def_rec f x y =>
@@ -24,11 +24,13 @@ Definition sumAcc_example := Eval compute in
     |].
 
 
-Eval compute in eval sumAcc_example 1000.
+
+Example sumAcc : (eval sumAcc_example 1000) =  Some [| 7 |].
+Proof.
+  native_compute; reflexivity. Qed.
 
 
+(* Extraction *)
 Extraction Language Ocaml.
 Set Extraction AccessOpaque.
-Extraction "sumAcc.ml" sumAcc_example eval. 
-
-
+Extraction "sumAcc.ml" sumAcc_example eval.


### PR DESCRIPTION
Using the notation mecanism of Coq, this PR aims at adding an easy way to directly write terms of the systemFR language using `[|` and `|]` brackets, with a **coq-like** syntax. A small-step evaluator, proven correct regarding the small steps rules, is provided. A set of examples (that resembles the Stainlessfit ones) is provided, both to test the features of the language and to measure the performance of the evaluator. It is to be noted that the **typed** version of the embedded language is less tested.