### PR TITLE
Integration of primitives

### DIFF
--- a/AnnotatedEquivalentPrimitive.v
+++ b/AnnotatedEquivalentPrimitive.v
@@ -1,0 +1,29 @@
+Require Export SystemFR.ErasedEquivalentPrimitive.
+Require Export SystemFR.Judgments.
+
+
+
+Lemma annotated_reducible_primitive_EqEquiv1:
+  forall Θ Γ t1 t2,
+    [[Θ; Γ ⊨ t1 : T_nat]] ->
+    [[Θ; Γ ⊨ t2 : T_nat]] ->
+    [[Θ; Γ ⊨ binary_primitive Eq t1 t2 ≡ ttrue ]] ->
+    [[Θ; Γ ⊨ t1 ≡ t2]].
+Proof. steps; eauto with primitives. Qed.
+
+Lemma annotated_reducible_primitive_EqEquiv2:
+  forall Θ Γ t1 t2,
+    [[Θ; Γ ⊨ t1 : T_nat]] ->
+    [[Θ; Γ ⊨ t2 : T_nat]] ->
+    [[Θ; Γ ⊨ t1 ≡ t2]] ->
+    [[Θ; Γ ⊨ binary_primitive Eq t1 t2 ≡ ttrue ]] .
+Proof. steps; eauto with primitives. Qed.
+
+
+Lemma annotated_reducible_primitive_Eq_sym:
+  forall Θ Γ t1 t2,
+    [[Θ; Γ ⊨ t1 : T_nat]] ->
+    [[Θ; Γ ⊨ t2 : T_nat]] ->
+    [[Θ; Γ ⊨ binary_primitive Eq t1 t2 ≡ ttrue ]] ->
+    [[Θ; Γ ⊨ binary_primitive Eq t2 t1 ≡ ttrue ]].
+Proof. steps; eauto with primitives. Qed.

--- a/AnnotatedFix.v
+++ b/AnnotatedFix.v
@@ -3,7 +3,6 @@ Require Import Coq.Lists.List.
 Require Export SystemFR.Judgments.
 Require Export SystemFR.AnnotatedTactics.
 Require Export SystemFR.ErasedFix.
-Require Export SystemFR.NatLessThanErase.
 
 Opaque reducible_values.
 
@@ -31,7 +30,7 @@ Lemma annotated_reducible_fix_strong_induction:
     cbv_value (erase_term ts) ->
     [[ Θ;
         (p, T_equiv (fvar y term_var) (tfix T ts)) ::
-        (y, T_forall (T_refine T_nat (annotated_tlt (lvar 0 term_var) (fvar n term_var))) T) ::
+        (y, T_forall (T_refine T_nat (binary_primitive Lt (lvar 0 term_var) (fvar n term_var))) T) ::
         (n, T_nat) ::
         Γ ⊨
         open 0 (open 1 ts (fvar n term_var)) (fvar y term_var) :

--- a/AnnotatedPrimitive.v
+++ b/AnnotatedPrimitive.v
@@ -1,0 +1,88 @@
+Require Export SystemFR.ErasedPrimitive.
+Require Export SystemFR.Judgments.
+
+Lemma annotated_reducible_primitive_Plus:
+  forall Θ Γ t1 t2,
+    [[ Θ; Γ ⊨ t1 : T_nat ]] ->
+    [[ Θ; Γ ⊨ t2 : T_nat ]] ->
+    [[ Θ; Γ ⊨ binary_primitive Plus t1 t2 : T_nat]].
+Proof. steps; eauto with primitives. Qed.
+
+Lemma annotated_reducible_primitive_Minus:
+  forall Θ Γ t1 t2,
+    [[ Θ; Γ ⊨ t1 : T_nat ]] ->
+    [[ Θ; Γ ⊨ t2 : T_nat ]] ->
+    [[ Θ; Γ ⊨ binary_primitive Geq t1 t2 ≡ ttrue ]] ->
+    [[ Θ; Γ ⊨ binary_primitive Minus t1 t2 : T_nat]].
+Proof. steps; eauto with primitives. Qed.
+
+Lemma annotated_reducible_primitive_Mul:
+  forall Θ Γ t1 t2,
+    [[ Θ; Γ ⊨ t1 : T_nat ]] ->
+    [[ Θ; Γ ⊨ t2 : T_nat ]] ->
+    [[ Θ; Γ ⊨ binary_primitive Mul t1 t2 : T_nat]].
+Proof. steps; eauto with primitives. Qed.
+
+Lemma annotated_reducible_primitive_Div:
+  forall Θ Γ t1 t2,
+    [[ Θ; Γ ⊨ t1 : T_nat ]] ->
+    [[ Θ; Γ ⊨ t2 : T_nat ]] ->
+    [[ Θ; Γ ⊨ binary_primitive Gt t2 zero ≡ ttrue ]] ->
+    [[ Θ; Γ ⊨ binary_primitive Div t1 t2 : T_nat]].
+Proof. steps; eauto with primitives. Qed.
+
+Lemma annotated_reducible_primitive_Lt:
+  forall Θ Γ t1 t2,
+    [[ Θ; Γ ⊨ t1 : T_nat ]] ->
+    [[ Θ; Γ ⊨ t2 : T_nat ]] ->
+    [[ Θ; Γ ⊨ binary_primitive Lt t1 t2 : T_bool]].
+Proof. steps; eauto with primitives. Qed.
+
+Lemma annotated_reducible_primitive_Leq:
+  forall Θ Γ t1 t2,
+    [[ Θ; Γ ⊨ t1 : T_nat ]] ->
+    [[ Θ; Γ ⊨ t2 : T_nat ]] ->
+    [[ Θ; Γ ⊨ binary_primitive Leq t1 t2 : T_bool]].
+Proof. steps; eauto with primitives. Qed.
+
+Lemma annotated_reducible_primitive_Gt:
+  forall Θ Γ t1 t2,
+    [[ Θ; Γ ⊨ t1 : T_nat ]] ->
+    [[ Θ; Γ ⊨ t2 : T_nat ]] ->
+    [[ Θ; Γ ⊨ binary_primitive Gt t1 t2 : T_bool]].
+Proof. steps; eauto with primitives. Qed.
+
+Lemma annotated_reducible_primitive_Geq:
+  forall Θ Γ t1 t2,
+    [[ Θ; Γ ⊨ t1 : T_nat ]] ->
+    [[ Θ; Γ ⊨ t2 : T_nat ]] ->
+    [[ Θ; Γ ⊨ binary_primitive Geq t1 t2 : T_bool]].
+Proof. steps; eauto with primitives. Qed.
+
+Lemma annotated_reducible_primitive_Eq:
+  forall Θ Γ t1 t2,
+    [[ Θ; Γ ⊨ t1 : T_nat ]] ->
+    [[ Θ; Γ ⊨ t2 : T_nat ]] ->
+    [[ Θ; Γ ⊨ binary_primitive Eq t1 t2 : T_bool]].
+Proof. steps; eauto with primitives. Qed.
+
+Lemma annotated_reducible_primitive_Neq:
+  forall Θ Γ t1 t2,
+    [[ Θ; Γ ⊨ t1 : T_nat ]] ->
+    [[ Θ; Γ ⊨ t2 : T_nat ]] ->
+    [[ Θ; Γ ⊨ binary_primitive Neq t1 t2 : T_bool]].
+Proof. steps; eauto with primitives. Qed.
+
+Lemma annotated_reducible_primitive_And:
+  forall Θ Γ t1 t2,
+    [[ Θ; Γ ⊨ t1 : T_bool ]] ->
+    [[ Θ; Γ ⊨ t2 : T_bool ]] ->
+    [[ Θ; Γ ⊨ binary_primitive And t1 t2 : T_bool]].
+Proof. steps; eauto with primitives. Qed.
+
+Lemma annotated_reducible_primitive_Or:
+  forall Θ Γ t1 t2,
+    [[ Θ; Γ ⊨ t1 : T_bool ]] ->
+    [[ Θ; Γ ⊨ t2 : T_bool ]] ->
+    [[ Θ; Γ ⊨ binary_primitive Or t1 t2 : T_bool]].
+Proof. steps; eauto with primitives. Qed.

--- a/AnnotatedPrimitive.v
+++ b/AnnotatedPrimitive.v
@@ -1,6 +1,12 @@
 Require Export SystemFR.ErasedPrimitive.
 Require Export SystemFR.Judgments.
 
+Lemma annotated_reducible_primitive_Not:
+  forall Θ Γ t1,
+    [[ Θ; Γ ⊨ t1 : T_bool ]] ->
+    [[ Θ; Γ ⊨ unary_primitive Not t1 : T_bool]].
+Proof. steps; eauto with primitives. Qed.
+
 Lemma annotated_reducible_primitive_Plus:
   forall Θ Γ t1 t2,
     [[ Θ; Γ ⊨ t1 : T_nat ]] ->

--- a/AnnotatedRec.v
+++ b/AnnotatedRec.v
@@ -3,7 +3,6 @@ Require Import Coq.Lists.List.
 Require Export SystemFR.ErasedRec.
 Require Export SystemFR.AnnotatedTactics.
 Require Export SystemFR.Judgments.
-Require Export SystemFR.NatLessThanErase.
 
 Opaque reducible_values.
 
@@ -152,7 +151,7 @@ Lemma annnotated_reducible_unfold_pos_in:
     subset (fv T0) (support Γ) ->
     subset (fv Ts) (support Γ) ->
     [[ Θ; Γ ⊨ t1 : T_rec n T0 Ts ]] ->
-    [[ Θ; Γ ⊨ annotated_tlt zero n ≡ ttrue ]] ->
+    [[ Θ; Γ ⊨ binary_primitive Lt zero n ≡ ttrue ]] ->
     [[ Θ; (p1, T_equiv t1 (tfold (T_rec n T0 Ts) (fvar y term_var))) ::
               (y, topen 0 Ts (T_rec (tpred n) T0 Ts)) ::
               Γ  ⊨

--- a/AnnotatedSubtypeRec.v
+++ b/AnnotatedSubtypeRec.v
@@ -1,11 +1,8 @@
 Require Export SystemFR.Judgments.
 Require Export SystemFR.AnnotatedTactics.
-Require Export SystemFR.NatLessThanErase.
 Require Export SystemFR.PolarityErase.
 Require Export SystemFR.ErasedRecPos.
 
-Opaque tlt.
-Opaque annotated_tlt.
 Opaque reducible_values.
 
 Lemma annotated_subtype_rec:
@@ -32,7 +29,7 @@ Lemma annotated_subtype_rec_pos:
     ~(X ∈ pfv Ts type_var) ->
     ~(X ∈ Θ) ->
     has_polarities (topen 0 Ts (fvar X type_var)) ((X, Positive) :: nil) ->
-    [[ Θ; Γ ⊨ annotated_tlt n1 (succ n2) ≡ ttrue ]] ->
+    [[ Θ; Γ ⊨ binary_primitive Lt n1 (succ n2) ≡ ttrue ]] ->
     [[ Θ; Γ ⊨ n1 : T_nat ]] ->
     [[ Θ; Γ ⊨ topen 0 Ts (T_rec zero T0 Ts) <: T0 ]] ->
     [[ Θ; Γ ⊨ T_rec n2 T0 Ts <: T_rec n1 T0 Ts ]].

--- a/EqualWithRelation.v
+++ b/EqualWithRelation.v
@@ -3,6 +3,7 @@ Require Import PeanoNat.
 
 Require Export SystemFR.SizeLemmas.
 Require Export SystemFR.StarLemmas.
+Require Export SystemFR.FVLemmasEval.
 
 Open Scope list_scope.
 
@@ -103,6 +104,17 @@ Inductive equal_with_relation tag rel: tree -> tree -> Prop :=
       equal_with_relation tag rel t2 t2' ->
       equal_with_relation tag rel t3 t3' ->
       equal_with_relation tag rel (tmatch t1 t2 t3) (tmatch t1' t2' t3')
+
+| EWRUnaryPrimitive:
+    forall o t1 t1',
+      equal_with_relation tag rel t1 t1' ->
+      equal_with_relation tag rel (unary_primitive o t1) (unary_primitive o t1')
+| EWRBinaryPrimitive:
+    forall o t1 t1' t2 t2',
+      equal_with_relation tag rel t1 t1' ->
+      equal_with_relation tag rel t2 t2' ->
+      equal_with_relation tag rel (binary_primitive o t1 t2) (binary_primitive o t1' t2')
+
 | EWRNoTypeLet:
     forall t1 t1' t2 t2',
       equal_with_relation tag rel t1 t1' ->
@@ -484,6 +496,27 @@ Proof.
     eauto with values.
 Qed.
 
+Lemma equal_with_relation_build_nat:
+  forall n t rel tag,
+    equal_with_relation tag rel t (build_nat n) ->
+    t = build_nat n.
+Proof.
+  induction n;
+    repeat steps || step_inversion equal_with_relation.
+  apply IHn in H2; steps.
+Qed.
+
+Lemma equal_with_relation_build_nat2:
+  forall n t rel tag,
+    equal_with_relation tag rel (build_nat n) t ->
+    t = build_nat n.
+Proof.
+  induction n;
+    repeat steps || step_inversion equal_with_relation.
+  apply IHn in H1; steps.
+Qed.
+
+
 Ltac t_ewr_value :=
   match goal with
   | H1: equal_with_relation _ _ ?v ?v2, H2: cbv_value ?v |- _ =>
@@ -607,6 +640,7 @@ Proof.
     repeat step || t_ewr_nil || t_ewr_value || instantiate_any ||
       step_inversion equal_with_relation ||
       apply equal_with_relation_open2 ||
+      eapply_anywhere equal_with_relation_build_nat2 ||
       (erewrite equal_with_relation_tsize by eauto) ||
       (erewrite equal_with_relation_lambda by eauto) ||
       (erewrite equal_with_relation_succ by eauto) ||
@@ -618,6 +652,7 @@ Proof.
       eauto using equal_with_relation_top_level_var3, equal_with_relation_lambda_refl with smallstep;
       eauto using equal_with_relation_top_level_var3, equal_with_relation_succ_refl with smallstep.
 Qed.
+
 
 Ltac equal_with_relation_scbv_step :=
   match goal with

--- a/EquivalentStar.v
+++ b/EquivalentStar.v
@@ -210,6 +210,14 @@ Proof.
     eauto using term_lift_refl.
 Qed.
 
+Lemma term_lift_inter_reducible_sym:
+  forall t1 t2,
+    term_lift inter_reducible t1 t2 ->
+    term_lift inter_reducible t2 t1.
+Proof.
+  intros; eauto using term_lift_sym, inter_reducible_sym.
+Qed.
+
 Lemma term_lift_inter_reducible_pair:
   forall t v,
     term_lift inter_reducible t v ->
@@ -291,6 +299,39 @@ Proof.
   eexists; steps;
     try solve [ constructor; unfold inter_reducible; steps; eauto with fv ].
 Qed.
+
+Lemma term_lift_inter_reducible_build_nat:
+  forall v t,
+    term_lift inter_reducible t v ->
+    forall n, (
+        t = build_nat n ->
+        cbv_value v ->
+        v = build_nat n).
+Proof.
+  intros v t H.
+  induction H; steps; try solve [destruct n; discriminate].
+  + apply inter_reducible_value in H; try star_smallstep_value; eauto with values.
+  + destruct n; steps. inversion H1; steps.
+Qed.
+
+Lemma term_lift_inter_reducible_build_nat2:
+  forall v n,
+    term_lift inter_reducible (build_nat n) v ->
+    cbv_value v ->
+    v = build_nat n.
+Proof.
+  eauto using term_lift_inter_reducible_build_nat.
+Qed.
+
+Ltac term_lift_inter_reducible_build_nat :=
+  match goal with
+  | H1: term_lift inter_reducible (build_nat ?n) ?t, H2: cbv_value ?t |- _ =>
+    pose proof (term_lift_inter_reducible_build_nat2 t n H1 H2); subst; clear H1
+  | H1: term_lift inter_reducible ?t (build_nat ?n), H2: cbv_value ?t |- _ =>
+    apply term_lift_inter_reducible_sym in H1;
+    pose proof (term_lift_inter_reducible_build_nat2 t n H1 H2); subst; clear H1
+  end.
+
 
 Lemma term_lift_inter_reducible_left:
   forall t v,
@@ -413,6 +454,7 @@ Proof.
     repeat step || t_invert_star.
 Qed.
 
+
 Lemma term_lift_inter_reducible_top_level_var:
   forall v1 v2,
     term_lift inter_reducible v1 v2 ->
@@ -439,6 +481,9 @@ Proof.
     try solve [ apply_anywhere inter_reducible_values; steps ].
 Qed.
 
+Opaque PeanoNat.Nat.leb.
+Opaque PeanoNat.Nat.ltb.
+
 Lemma term_lift_inter_reducible_step:
   forall t1 t2,
     term_lift inter_reducible t1 t2 ->
@@ -455,6 +500,29 @@ Proof.
     repeat step || t_invert_step || instantiate_any || list_utils;
     eauto using inter_reducible_step with star smallstep term_lift;
     eauto with cbvlemmas term_lift.
+  all: try solve [
+
+   repeat term_lift_inter_reducible_value; steps;
+   repeat term_lift_inter_reducible_build_nat; steps;
+   repeat match goal with
+          | H1: term_lift inter_reducible ttrue ?v, H2: cbv_value ?v |- _ =>
+            pose proof (term_lift_inter_reducible_true ttrue v H1 eq_refl H2); subst; clear H1
+          | H1: term_lift inter_reducible tfalse ?v, H2: cbv_value ?v |- _ =>
+            pose proof (term_lift_inter_reducible_false tfalse v H1 eq_refl H2); subst; clear H1
+          end;
+        eauto with values;
+        eauto using term_lift_sym, inter_reducible_sym;
+    eexists; split; [
+      apply term_lift_refl; steps; eauto with erased
+    | eapply star_trans;
+      try eapply star_smallstep_binary_primitive; try eassumption;
+      apply star_one; eapply scbv_step_same; eauto with smallstep erased; steps]
+].
+
+
+
+
+
 
   - eexists; steps; eauto using term_lift_inter_reducible_tsize, term_lift_sym, inter_reducible_sym.
     apply term_lift_refl; eauto with erased.
@@ -494,6 +562,26 @@ Proof.
     eapply term_lift_inter_reducible_pair in H13; repeat step || list_utils || step_inversion cbv_value;
       eauto with fv; eauto with wf; eauto with erased;
       eauto 7 using star_trans with cbvlemmas smallstep.
+
+  - repeat term_lift_inter_reducible_value; steps;
+      eauto with values;
+      eauto using term_lift_sym, inter_reducible_sym.
+    apply_anywhere term_lift_inter_reducible_true; eauto with values; subst.
+    eexists; split; eauto using star_trans, star_one, star_smallstep_unary_primitive, term_lift_refl with smallstep.
+
+  - repeat term_lift_inter_reducible_value; steps;
+      eauto with values;
+      eauto using term_lift_sym, inter_reducible_sym.
+    apply_anywhere term_lift_inter_reducible_false; eauto with values; subst.
+    eexists; split; eauto using star_trans, star_one, star_smallstep_unary_primitive, term_lift_refl with smallstep.
+
+  - repeat term_lift_inter_reducible_value; steps;
+      eauto with values;
+      eauto using term_lift_sym, inter_reducible_sym.
+    eexists; split.
+    apply LiBinaryPrimitive ; try eassumption.
+    eauto using star_trans, star_smallstep_binary_primitive_l, star_smallstep_binary_primitive_r.
+
 
   - repeat term_lift_inter_reducible_value; steps;
       eauto with values;

--- a/ErasedEquivalentPrimitive.v
+++ b/ErasedEquivalentPrimitive.v
@@ -1,0 +1,133 @@
+Require Export SystemFR.ErasedPrimitive.
+
+
+Lemma reducible_values_primitive_EqEquiv1:
+  forall ρ v1 v2,
+    [ ρ ⊨ v1 : T_nat ]v ->
+    [ ρ ⊨ v2 : T_nat ]v ->
+    [ binary_primitive Eq v1 v2 ≡ ttrue ] ->
+    [ v1 ≡ v2 ].
+Proof.
+  unfold reduces_to; intros; repeat simp_red; repeat is_nat_value_buildable; steps.
+  apply_anywhere equivalent_true; last_step_binary_primitive.
+  rewrite PeanoNat.Nat.eqb_eq in *; subst.
+  unfold equivalent_terms; steps; eauto with erased values wf fv.
+Qed.
+
+Opaque Coq.Init.Wf.Fix_F.
+Opaque  Subterm.FixWf.
+
+Lemma reducible_primitive_EqEquiv1:
+  forall ρ t1 t2,
+    valid_interpretation ρ ->
+    [ ρ ⊨ t1 : T_nat ] ->
+    [ ρ ⊨ t2 : T_nat ] ->
+    [ binary_primitive Eq t1 t2 ≡ ttrue ] ->
+    [ t1 ≡ t2 ].
+Proof.
+  intros;
+    repeat steps || simp_red || is_nat_value_buildable || unfold closed_term in * || top_level_unfold reduces_to ; eauto with erased wf.
+  eapply equivalent_trans; [
+    apply equivalent_star; eauto with erased wf fv | idtac].
+  eapply equivalent_sym, equivalent_trans; [equivalent_star | idtac].
+  apply equivalent_sym.
+  eapply (reducible_values_primitive_EqEquiv1 ρ); unfold reduces_to; steps;
+    autorewrite with reducible_values; eauto with cbvlemmas values reducible_values.
+  eapply equivalent_trans; [idtac | eauto using equivalent_refl with fv erased values].
+  apply equivalent_sym, equivalent_star;
+    repeat steps || list_utils ; eauto with wf erased fv.
+  apply star_smallstep_binary_primitive; eauto with values.
+Qed.
+
+Lemma open_reducible_primitive_EqEquiv1:
+  forall Θ Γ t1 t2,
+    [Θ; Γ ⊨ t1 : T_nat] ->
+    [Θ; Γ ⊨ t2 : T_nat] ->
+    [Θ; Γ ⊨ binary_primitive Eq t1 t2 ≡ ttrue ] ->
+    [Θ; Γ ⊨ t1 ≡ t2].
+Proof. unfold open_reducible, open_equivalent; steps;
+         eauto using reducible_primitive_EqEquiv1.
+Qed.
+
+Hint Resolve open_reducible_primitive_EqEquiv1: primitives.
+
+Lemma equivalent_build_nat:
+  forall n1 n2,
+    [build_nat n1 ≡ build_nat n2] ->
+    n1 = n2.
+Proof.
+  unfold equivalent_terms; steps.
+  specialize (H6 (binary_primitive Eq (lvar 0 term_var) (build_nat n2))); steps.
+  repeat (rewrite open_none in H6; eauto with wf).
+  assert (binary_primitive Eq (build_nat n1) (build_nat n2) ~> ttrue). {
+    apply last_step_binary_primitive; eauto with values.
+    apply H6; try Psatz.lia; eauto with wf smallstep.
+    apply star_one. pose proof (SPBetaEq _ _ n2 n2 eq_refl eq_refl); steps.
+    rewrite PeanoNat.Nat.eqb_neq in *; steps.
+    }
+  t_invert_step; repeat steps || rewrite PeanoNat.Nat.eqb_eq in * || build_nat_inj.
+Qed.
+
+Ltac equivalent_build_nat :=
+  match goal with
+  | H: [ build_nat ?n1 ≡ build_nat ?n2 ] |- _ => apply equivalent_build_nat in H; subst
+  end.
+
+
+Lemma reducible_values_primitive_EqEquiv2:
+  forall ρ v1 v2,
+    [ ρ ⊨ v1 : T_nat ]v ->
+    [ ρ ⊨ v2 : T_nat ]v ->
+    [ v1 ≡ v2 ] ->
+    [ binary_primitive Eq v1 v2 ≡ ttrue ].
+Proof.
+  unfold reduces_to; repeat simp_red || is_nat_value_buildable || steps || equivalent_build_nat.
+  eapply equivalent_star; repeat steps || list_utils; eauto with smallstep wf fv erased.
+  apply star_one. epose proof (SPBetaEq _ _ n0 n0); repeat rewrite PeanoNat.Nat.eqb_neq in * || steps.
+Qed.
+
+Lemma reducible_primitive_EqEquiv2:
+  forall ρ t1 t2,
+    (valid_interpretation ρ) ->
+    [ ρ ⊨ t1 : T_nat ] ->
+    [ ρ ⊨ t2 : T_nat ] ->
+    [ t1 ≡ t2 ] ->
+    [ binary_primitive Eq t1 t2 ≡ ttrue ].
+Proof.
+  intros;
+    repeat steps || simp_red || is_nat_value_buildable || unfold closed_term in * || top_level_unfold reduces_to ; eauto with erased wf.
+
+  eapply equivalent_trans.
+  apply equivalent_star; repeat steps || list_utils ; eauto with erased wf fv.
+  apply star_smallstep_binary_primitive; eauto using cbv_value_build_nat.
+  unshelve eapply reducible_values_primitive_EqEquiv2; unfold reduces_to; steps;
+    autorewrite with reducible_values; eauto with cbvlemmas values reducible_values.
+  eapply equivalent_trans. apply equivalent_sym. equivalent_star.
+  eapply equivalent_trans; eauto. equivalent_star.
+Qed.
+
+
+Lemma open_reducible_primitive_EqEquiv2:
+  forall Θ Γ t1 t2,
+    [Θ; Γ ⊨ t1 : T_nat] ->
+    [Θ; Γ ⊨ t2 : T_nat] ->
+    [Θ; Γ ⊨ t1 ≡ t2] ->
+    [Θ; Γ ⊨ binary_primitive Eq t1 t2 ≡ ttrue ].
+Proof. unfold open_reducible, open_equivalent; steps;
+         eauto using reducible_primitive_EqEquiv2.
+Qed.
+Hint Resolve open_reducible_primitive_EqEquiv2: primitives.
+
+Lemma open_reducible_primitive_EqSym:
+  forall Θ Γ t1 t2,
+    [Θ; Γ ⊨ t1 : T_nat] ->
+    [Θ; Γ ⊨ t2 : T_nat] ->
+    [Θ; Γ ⊨ binary_primitive Eq t1 t2 ≡ ttrue ] ->
+    [Θ; Γ ⊨ binary_primitive Eq t2 t1 ≡ ttrue ].
+Proof.
+  steps.
+  apply open_reducible_primitive_EqEquiv2; eauto.
+  assert ([Θ; Γ ⊨ t1 ≡ t2]). apply open_reducible_primitive_EqEquiv1; eauto.
+  unfold open_equivalent in * ; steps ; eauto using equivalent_sym.
+Qed.
+Hint Resolve open_reducible_primitive_EqSym: primitives.

--- a/ErasedEquivalentPrimitive.v
+++ b/ErasedEquivalentPrimitive.v
@@ -1,16 +1,17 @@
 Require Export SystemFR.ErasedPrimitive.
+Require Import Coq.Strings.String.
 
 
 Lemma reducible_values_primitive_EqEquiv1:
-  forall ρ v1 v2,
-    [ ρ ⊨ v1 : T_nat ]v ->
-    [ ρ ⊨ v2 : T_nat ]v ->
+  forall v1 v2,
+    cbv_value v1 ->
+    cbv_value v2 ->
     [ binary_primitive Eq v1 v2 ≡ ttrue ] ->
     [ v1 ≡ v2 ].
 Proof.
   unfold reduces_to; intros; repeat simp_red; repeat is_nat_value_buildable; steps.
-  apply_anywhere equivalent_true; last_step_binary_primitive.
-  rewrite PeanoNat.Nat.eqb_eq in *; subst.
+  apply_anywhere equivalent_true. last_step_binary_primitive.
+   rewrite PeanoNat.Nat.eqb_eq in *; subst.
   unfold equivalent_terms; steps; eauto with erased values wf fv.
 Qed.
 
@@ -18,31 +19,28 @@ Opaque Coq.Init.Wf.Fix_F.
 Opaque  Subterm.FixWf.
 
 Lemma reducible_primitive_EqEquiv1:
-  forall ρ t1 t2,
-    valid_interpretation ρ ->
-    [ ρ ⊨ t1 : T_nat ] ->
-    [ ρ ⊨ t2 : T_nat ] ->
+  forall t1 t2,
     [ binary_primitive Eq t1 t2 ≡ ttrue ] ->
     [ t1 ≡ t2 ].
 Proof.
-  intros;
-    repeat steps || simp_red || is_nat_value_buildable || unfold closed_term in * || top_level_unfold reduces_to ; eauto with erased wf.
-  eapply equivalent_trans; [
-    apply equivalent_star; eauto with erased wf fv | idtac].
+  steps.
+  pose proof H.
+  apply_anywhere equivalent_true.
+  t_invert_star; eauto with values. steps.
+  eapply equivalent_trans; [ top_level_unfold equivalent_terms;
+    apply equivalent_star; eauto with erased wf fv; t_closer | idtac].
   eapply equivalent_sym, equivalent_trans; [equivalent_star | idtac].
   apply equivalent_sym.
-  eapply (reducible_values_primitive_EqEquiv1 ρ); unfold reduces_to; steps;
+  eapply reducible_values_primitive_EqEquiv1; unfold reduces_to; steps;
     autorewrite with reducible_values; eauto with cbvlemmas values reducible_values.
   eapply equivalent_trans; [idtac | eauto using equivalent_refl with fv erased values].
   apply equivalent_sym, equivalent_star;
-    repeat steps || list_utils ; eauto with wf erased fv.
+    repeat steps || list_utils || top_level_unfold equivalent_terms ; eauto with wf erased fv.
   apply star_smallstep_binary_primitive; eauto with values.
 Qed.
 
 Lemma open_reducible_primitive_EqEquiv1:
   forall Θ Γ t1 t2,
-    [Θ; Γ ⊨ t1 : T_nat] ->
-    [Θ; Γ ⊨ t2 : T_nat] ->
     [Θ; Γ ⊨ binary_primitive Eq t1 t2 ≡ ttrue ] ->
     [Θ; Γ ⊨ t1 ≡ t2].
 Proof. unfold open_reducible, open_equivalent; steps;
@@ -118,16 +116,58 @@ Proof. unfold open_reducible, open_equivalent; steps;
 Qed.
 Hint Resolve open_reducible_primitive_EqEquiv2: primitives.
 
+Lemma open_reducible_primitive_Eq_args:
+  forall Θ Γ t1 t2,
+    [Θ; Γ ⊨ binary_primitive Eq t1 t2 ≡ ttrue ] ->
+    [Θ; Γ ⊨ t1 : T_nat] /\ [Θ; Γ ⊨ t2 : T_nat].
+Proof.
+  intros. unfold open_equivalent, open_reducible in *; steps; specialize (H ρ lterms); intuition auto;
+  assert (closed_term (psubstitute t2 lterms term_var)) by
+      (unfold equivalent_terms, closed_term, open_equivalent, open_reducible in *; repeat steps || list_utils);
+  assert (closed_term (psubstitute t1 lterms term_var)) by
+      (unfold equivalent_terms, closed_term, open_equivalent, open_reducible in *; repeat steps || list_utils);
+  apply_anywhere equivalent_true;
+  eapply_anywhere star_smallstep_binary_primitive_inv; eauto with values; steps;
+  step_inversion scbv_step; steps;
+  unfold reduces_to; steps; eauto with values smallstep;
+  eexists; split; eauto;
+  rewrite reducible_values_equation_4; apply is_nat_value_build_nat.
+Qed.
+
+
 Lemma open_reducible_primitive_EqSym:
   forall Θ Γ t1 t2,
-    [Θ; Γ ⊨ t1 : T_nat] ->
-    [Θ; Γ ⊨ t2 : T_nat] ->
     [Θ; Γ ⊨ binary_primitive Eq t1 t2 ≡ ttrue ] ->
     [Θ; Γ ⊨ binary_primitive Eq t2 t1 ≡ ttrue ].
 Proof.
   steps.
-  apply open_reducible_primitive_EqEquiv2; eauto.
+  apply open_reducible_primitive_EqEquiv2;
+    try solve [
+          apply_anywhere open_reducible_primitive_Eq_args; steps].
   assert ([Θ; Γ ⊨ t1 ≡ t2]). apply open_reducible_primitive_EqEquiv1; eauto.
   unfold open_equivalent in * ; steps ; eauto using equivalent_sym.
 Qed.
 Hint Resolve open_reducible_primitive_EqSym: primitives.
+
+Lemma reducible_values_primitive_Lt_sound:
+  forall a b, cbv_value a ->
+         cbv_value b ->
+         [ binary_primitive Lt a b ≡ ttrue] ->
+         tree_size a < tree_size b.
+Proof.
+  intros.
+  apply_anywhere equivalent_true. last_step_binary_primitive.
+  repeat rewrite tree_size_build_nat; steps. Psatz.lia.
+Qed.
+
+Ltac reducible_values_primitive_Lt_sound :=
+  match goal with
+  | H: binary_primitive Lt ?a ?b ~>* ttrue |- _ =>
+    cbv_value a; cbv_value b;
+    poseNew (Mark (a,b) "reducible_values_primitive_Lt_sound");
+    unshelve epose proof (reducible_values_primitive_Lt_sound a b _ _ H)
+  | H: [ binary_primitive Lt ?a ?b ≡ ttrue ] |- _ =>
+    cbv_value a; cbv_value b;
+    poseNew (Mark (a,b) "reducible_values_primitive_Lt_sound");
+    unshelve epose proof (reducible_values_primitive_Lt_sound a b _ _ _)
+  end.

--- a/ErasedErr.v
+++ b/ErasedErr.v
@@ -1,5 +1,4 @@
 Require Export SystemFR.RedTactics.
-Require Export SystemFR.NatLessThan.
 
 Lemma open_reducible_err:
   forall Θ Γ T,

--- a/ErasedPrimitive.v
+++ b/ErasedPrimitive.v
@@ -1,0 +1,289 @@
+Require Export SystemFR.ReducibilityOpenEquivalent.
+
+Opaque reducible_values.
+Opaque makeFresh.
+
+Ltac reducible_values_primitive :=
+  unfold reduces_to, closed_term ;
+    repeat step || simp_red || is_nat_value_buildable ; t_closer ;
+      eexists; split; [ idtac | (apply star_one; constructor; try reflexivity ) ];
+      eauto using is_nat_value_build_nat.
+Ltac reducible_primitive f :=
+  intros;
+  repeat top_level_unfold reduces_to || steps || simp_red || is_nat_value_buildable;
+  eapply star_backstep_reducible;
+    try apply star_smallstep_binary_primitive; eauto ;
+    repeat steps || list_utils || simp_red || apply f || eauto with values cbvlemmas ; t_closer.
+
+Hint Rewrite PeanoNat.Nat.leb_le: primitives.
+Hint Rewrite PeanoNat.Nat.leb_gt: primitives.
+Hint Rewrite PeanoNat.Nat.ltb_lt: primitives.
+Hint Rewrite PeanoNat.Nat.ltb_ge: primitives.
+
+Ltac equivalent_binary_primitive :=
+  lazymatch goal with
+  | H: binary_primitive ?o ?v1 ?v2 ~>* ?v |- _ =>
+    cbv_value v1 ; cbv_value v2 ;
+      inversion H; clear H; t_invert_step ;
+        try solve [exfalso; eauto with smallstep values ] ;
+        repeat build_nat_inj || subst ;
+        destruct_match; star_smallstep_value; try discriminate; eauto with values ;
+        repeat autorewrite with primitives in *
+  end.
+
+
+(* Plus *)
+
+Lemma reducible_values_primitive_plus:
+  forall ρ v1 v2,
+    [ ρ ⊨ v1 : T_nat ]v ->
+    [ ρ ⊨ v2 : T_nat ]v ->
+    [ ρ ⊨ binary_primitive Plus v1 v2 : T_nat ].
+Proof. reducible_values_primitive. Qed.
+
+Lemma reducible_primitive_plus:
+  forall ρ t1 t2,
+    valid_interpretation ρ ->
+    [ ρ ⊨ t1 : T_nat ] ->
+    [ ρ ⊨ t2 : T_nat ] ->
+    [ ρ ⊨ binary_primitive Plus t1 t2 : T_nat ].
+Proof. reducible_primitive reducible_values_primitive_plus. Qed.
+
+Lemma open_reducible_primitive_plus:
+  forall Θ Γ t1 t2,
+    [Θ; Γ ⊨ t1 : T_nat] ->
+    [Θ; Γ ⊨ t2 : T_nat] ->
+    [Θ; Γ ⊨ binary_primitive Plus t1 t2 : T_nat].
+Proof. unfold open_reducible; steps ; eauto using reducible_primitive_plus. Qed.
+
+(* Minus *)
+
+Lemma reducible_values_primitive_minus:
+  forall ρ v1 v2,
+    [ ρ ⊨ v1 : T_nat ]v ->
+    [ ρ ⊨ v2 : T_nat ]v ->
+    [ binary_primitive Geq v1 v2 ≡ ttrue ] ->
+    [ ρ ⊨ binary_primitive Minus v1 v2 : T_nat ].
+Proof. reducible_values_primitive. apply_anywhere equivalent_true. equivalent_binary_primitive. steps. Qed.
+
+Lemma reducible_primitive_minus:
+  forall ρ t1 t2,
+    valid_interpretation ρ ->
+    [ ρ ⊨ t1 : T_nat ] ->
+    [ ρ ⊨ t2 : T_nat ] ->
+    [ binary_primitive Geq t1 t2 ≡ ttrue ] ->
+    [ ρ ⊨ binary_primitive Minus t1 t2 : T_nat ].
+Proof. reducible_primitive reducible_values_primitive_minus.
+       eapply equivalent_trans; eauto.
+       apply equivalent_sym, equivalent_star; eauto with cbvlemmas smallstep wf fv; t_closer.
+       apply star_smallstep_binary_primitive; eauto with values.
+Qed.
+
+Lemma open_reducible_primitive_minus:
+  forall Θ Γ t1 t2,
+    [Θ; Γ ⊨ t1 : T_nat] ->
+    [Θ; Γ ⊨ t2 : T_nat] ->
+    [Θ; Γ ⊨ binary_primitive Geq t1 t2 ≡ ttrue ] ->
+    [Θ; Γ ⊨ binary_primitive Minus t1 t2 : T_nat].
+Proof. unfold open_reducible, open_equivalent; steps;
+         eauto using reducible_primitive_minus.
+Qed.
+
+(* Mul *)
+
+Lemma reducible_values_primitive_mul:
+  forall ρ v1 v2,
+    [ ρ ⊨ v1 : T_nat ]v ->
+    [ ρ ⊨ v2 : T_nat ]v ->
+    [ ρ ⊨ binary_primitive Mul v1 v2 : T_nat ].
+Proof. reducible_values_primitive. Qed.
+
+Lemma reducible_primitive_mul:
+  forall ρ t1 t2,
+    valid_interpretation ρ ->
+    [ ρ ⊨ t1 : T_nat ] ->
+    [ ρ ⊨ t2 : T_nat ] ->
+    [ ρ ⊨ binary_primitive Mul t1 t2 : T_nat ].
+Proof. reducible_primitive reducible_values_primitive_mul. Qed.
+
+Lemma open_reducible_primitive_mul:
+  forall Θ Γ t1 t2,
+    [Θ; Γ ⊨ t1 : T_nat] ->
+    [Θ; Γ ⊨ t2 : T_nat] ->
+    [Θ; Γ ⊨ binary_primitive Mul t1 t2 : T_nat].
+Proof. unfold open_reducible; steps ; eauto using reducible_primitive_mul. Qed.
+
+(* Div *)
+
+Lemma reducible_values_primitive_div:
+  forall ρ v1 v2 ,
+    [ ρ ⊨ v1 : T_nat ]v ->
+    [ ρ ⊨ v2 : T_nat ]v ->
+    [ binary_primitive Gt v2 zero ≡ ttrue] ->
+    [ ρ ⊨ binary_primitive Div v1 v2 : T_nat ].
+Proof. reducible_values_primitive. apply_anywhere equivalent_true. equivalent_binary_primitive. steps. Qed.
+
+Lemma reducible_primitive_div:
+  forall ρ t1 t2,
+    valid_interpretation ρ ->
+    [ ρ ⊨ t1 : T_nat ] ->
+    [ ρ ⊨ t2 : T_nat ] ->
+    [ binary_primitive Gt t2 zero ≡ ttrue] ->
+    [ ρ ⊨ binary_primitive Div t1 t2 : T_nat ].
+Proof.
+  reducible_primitive reducible_values_primitive_div.
+  eapply equivalent_trans; eauto.
+  apply equivalent_sym, equivalent_star; eauto with cbvlemmas smallstep wf fv; t_closer.
+Qed.
+
+Lemma open_reducible_primitive_div:
+  forall Θ Γ t1 t2,
+    [Θ; Γ ⊨ t1 : T_nat] ->
+    [Θ; Γ ⊨ t2 : T_nat] ->
+    [Θ; Γ ⊨ binary_primitive Gt t2 zero ≡ ttrue ] ->
+    [Θ; Γ ⊨ binary_primitive Div t1 t2 : T_nat].
+Proof. unfold open_reducible, open_equivalent; steps ; eauto using reducible_primitive_div. Qed.
+
+(* Lt *)
+
+Lemma reducible_values_primitive_lt:
+  forall ρ v1 v2,
+    [ ρ ⊨ v1 : T_nat ]v ->
+    [ ρ ⊨ v2 : T_nat ]v ->
+    [ ρ ⊨ binary_primitive Lt v1 v2 : T_bool ].
+Proof. reducible_values_primitive. steps. Qed.
+
+Lemma reducible_primitive_lt:
+  forall ρ t1 t2,
+    valid_interpretation ρ ->
+    [ ρ ⊨ t1 : T_nat ] ->
+    [ ρ ⊨ t2 : T_nat ] ->
+    [ ρ ⊨ binary_primitive Lt t1 t2 : T_bool ].
+Proof. reducible_primitive reducible_values_primitive_lt. Qed.
+
+Lemma open_reducible_primitive_lt:
+  forall Θ Γ t1 t2,
+    [Θ; Γ ⊨ t1 : T_nat] ->
+    [Θ; Γ ⊨ t2 : T_nat] ->
+    [Θ; Γ ⊨ binary_primitive Lt t1 t2 : T_bool].
+Proof. unfold open_reducible; steps ; eauto using reducible_primitive_lt. Qed.
+
+(* Leq *)
+
+Lemma reducible_values_primitive_leq:
+  forall ρ v1 v2,
+    [ ρ ⊨ v1 : T_nat ]v ->
+    [ ρ ⊨ v2 : T_nat ]v ->
+    [ ρ ⊨ binary_primitive Leq v1 v2 : T_bool ].
+Proof. reducible_values_primitive. steps. Qed.
+
+Lemma reducible_primitive_leq:
+  forall ρ t1 t2,
+    valid_interpretation ρ ->
+    [ ρ ⊨ t1 : T_nat ] ->
+    [ ρ ⊨ t2 : T_nat ] ->
+    [ ρ ⊨ binary_primitive Leq t1 t2 : T_bool ].
+Proof. reducible_primitive reducible_values_primitive_leq. Qed.
+
+Lemma open_reducible_primitive_leq:
+  forall Θ Γ t1 t2,
+    [Θ; Γ ⊨ t1 : T_nat] ->
+    [Θ; Γ ⊨ t2 : T_nat] ->
+    [Θ; Γ ⊨ binary_primitive Leq t1 t2 : T_bool].
+Proof. unfold open_reducible; steps ; eauto using reducible_primitive_leq. Qed.
+
+(* Gt *)
+
+Lemma reducible_values_primitive_gt:
+  forall ρ v1 v2,
+    [ ρ ⊨ v1 : T_nat ]v ->
+    [ ρ ⊨ v2 : T_nat ]v ->
+    [ ρ ⊨ binary_primitive Gt v1 v2 : T_bool ].
+Proof. reducible_values_primitive. steps. Qed.
+
+Lemma reducible_primitive_gt:
+  forall ρ t1 t2,
+    valid_interpretation ρ ->
+    [ ρ ⊨ t1 : T_nat ] ->
+    [ ρ ⊨ t2 : T_nat ] ->
+    [ ρ ⊨ binary_primitive Gt t1 t2 : T_bool ].
+Proof. reducible_primitive reducible_values_primitive_gt. Qed.
+
+Lemma open_reducible_primitive_gt:
+  forall Θ Γ t1 t2,
+    [Θ; Γ ⊨ t1 : T_nat] ->
+    [Θ; Γ ⊨ t2 : T_nat] ->
+    [Θ; Γ ⊨ binary_primitive Gt t1 t2 : T_bool].
+Proof. unfold open_reducible; steps ; eauto using reducible_primitive_gt. Qed.
+
+(* Geq *)
+
+Lemma reducible_values_primitive_geq:
+  forall ρ v1 v2,
+    [ ρ ⊨ v1 : T_nat ]v ->
+    [ ρ ⊨ v2 : T_nat ]v ->
+    [ ρ ⊨ binary_primitive Geq v1 v2 : T_bool ].
+Proof. reducible_values_primitive. steps. Qed.
+
+Lemma reducible_primitive_geq:
+  forall ρ t1 t2,
+    valid_interpretation ρ ->
+    [ ρ ⊨ t1 : T_nat ] ->
+    [ ρ ⊨ t2 : T_nat ] ->
+    [ ρ ⊨ binary_primitive Geq t1 t2 : T_bool ].
+Proof. reducible_primitive reducible_values_primitive_geq. Qed.
+
+Lemma open_reducible_primitive_geq:
+  forall Θ Γ t1 t2,
+    [Θ; Γ ⊨ t1 : T_nat] ->
+    [Θ; Γ ⊨ t2 : T_nat] ->
+    [Θ; Γ ⊨ binary_primitive Geq t1 t2 : T_bool].
+Proof. unfold open_reducible; steps ; eauto using reducible_primitive_geq. Qed.
+
+(* Eq *)
+
+Lemma reducible_values_primitive_eq:
+  forall ρ v1 v2,
+    [ ρ ⊨ v1 : T_nat ]v ->
+    [ ρ ⊨ v2 : T_nat ]v ->
+    [ ρ ⊨ binary_primitive Eq v1 v2 : T_bool ].
+Proof. reducible_values_primitive. steps. Qed.
+
+Lemma reducible_primitive_eq:
+  forall ρ t1 t2,
+    valid_interpretation ρ ->
+    [ ρ ⊨ t1 : T_nat ] ->
+    [ ρ ⊨ t2 : T_nat ] ->
+    [ ρ ⊨ binary_primitive Eq t1 t2 : T_bool ].
+Proof. reducible_primitive reducible_values_primitive_eq. Qed.
+
+Lemma open_reducible_primitive_eq:
+  forall Θ Γ t1 t2,
+    [Θ; Γ ⊨ t1 : T_nat] ->
+    [Θ; Γ ⊨ t2 : T_nat] ->
+    [Θ; Γ ⊨ binary_primitive Eq t1 t2 : T_bool].
+Proof. unfold open_reducible; steps ; eauto using reducible_primitive_eq. Qed.
+
+(* Neq *)
+
+Lemma reducible_values_primitive_neq:
+  forall ρ v1 v2,
+    [ ρ ⊨ v1 : T_nat ]v ->
+    [ ρ ⊨ v2 : T_nat ]v ->
+    [ ρ ⊨ binary_primitive Neq v1 v2 : T_bool ].
+Proof. reducible_values_primitive. steps. Qed.
+
+Lemma reducible_primitive_neq:
+  forall ρ t1 t2,
+    valid_interpretation ρ ->
+    [ ρ ⊨ t1 : T_nat ] ->
+    [ ρ ⊨ t2 : T_nat ] ->
+    [ ρ ⊨ binary_primitive Neq t1 t2 : T_bool ].
+Proof. reducible_primitive reducible_values_primitive_neq. Qed.
+
+Lemma open_reducible_primitive_neq:
+  forall Θ Γ t1 t2,
+    [Θ; Γ ⊨ t1 : T_nat] ->
+    [Θ; Γ ⊨ t2 : T_nat] ->
+    [Θ; Γ ⊨ binary_primitive Neq t1 t2 : T_bool].
+Proof. unfold open_reducible; steps ; eauto using reducible_primitive_neq. Qed.

--- a/ErasedPrimitive.v
+++ b/ErasedPrimitive.v
@@ -3,11 +3,42 @@ Require Export SystemFR.ReducibilityOpenEquivalent.
 Opaque reducible_values.
 Opaque makeFresh.
 
+Hint Rewrite PeanoNat.Nat.leb_le: primitives.
+Hint Rewrite PeanoNat.Nat.leb_gt: primitives.
+Hint Rewrite PeanoNat.Nat.ltb_lt: primitives.
+Hint Rewrite PeanoNat.Nat.ltb_ge: primitives.
+
+Opaque PeanoNat.Nat.leb.
+Opaque PeanoNat.Nat.ltb.
+
+Lemma last_step_binary_primitive:
+  forall v1 v2 v o,
+    cbv_value v1 ->
+    cbv_value v2 ->
+    cbv_value v ->
+    binary_primitive o v1 v2 ~>* v ->
+    binary_primitive o v1 v2 ~> v.
+Proof.
+  intros.
+  inversion H2; clear H2.
+  destruct v; steps; step_inversion cbv_value.
+  force_invert scbv_step;
+    repeat star_smallstep_value || steps || constructor || no_step ; eauto with values smallstep ;
+      try solve [eapply scbv_step_same; [constructor |]; steps].
+Qed.
+
+Ltac last_step_binary_primitive :=
+    apply_anywhere last_step_binary_primitive; eauto with values;
+    force_invert scbv_step; repeat build_nat_inj || steps || autorewrite with primitives in *.
+
 Ltac reducible_values_primitive :=
-  unfold reduces_to, closed_term ;
-    repeat step || simp_red || is_nat_value_buildable ; t_closer ;
-      eexists; split; [ idtac | (apply star_one; constructor; try reflexivity ) ];
-      eauto using is_nat_value_build_nat.
+  unfold reduces_to; intros ;
+  repeat simp_red ;
+  repeat is_nat_value_buildable ; steps ;
+      (unfold closed_term; repeat light || rewrite app_eq_nil_iff ; eauto 1 with fv wf erased) ||
+      (eexists; split; [ idtac | (apply star_one; constructor; try reflexivity )] ;
+      eauto using is_nat_value_build_nat).
+
 Ltac reducible_primitive f :=
   intros;
   repeat top_level_unfold reduces_to || steps || simp_red || is_nat_value_buildable;
@@ -15,11 +46,7 @@ Ltac reducible_primitive f :=
     try apply star_smallstep_binary_primitive; eauto ;
     repeat steps || list_utils || simp_red || apply f || eauto with values cbvlemmas ; t_closer.
 
-Hint Rewrite PeanoNat.Nat.leb_le: primitives.
-Hint Rewrite PeanoNat.Nat.leb_gt: primitives.
-Hint Rewrite PeanoNat.Nat.ltb_lt: primitives.
-Hint Rewrite PeanoNat.Nat.ltb_ge: primitives.
-
+(*
 Ltac equivalent_binary_primitive :=
   lazymatch goal with
   | H: binary_primitive ?o ?v1 ?v2 ~>* ?v |- _ =>
@@ -30,100 +57,105 @@ Ltac equivalent_binary_primitive :=
         destruct_match; star_smallstep_value; try discriminate; eauto with values ;
         repeat autorewrite with primitives in *
   end.
-
+*)
 
 (* Plus *)
 
-Lemma reducible_values_primitive_plus:
+Lemma reducible_values_primitive_Plus:
   forall ρ v1 v2,
     [ ρ ⊨ v1 : T_nat ]v ->
     [ ρ ⊨ v2 : T_nat ]v ->
     [ ρ ⊨ binary_primitive Plus v1 v2 : T_nat ].
 Proof. reducible_values_primitive. Qed.
 
-Lemma reducible_primitive_plus:
+Lemma reducible_primitive_Plus:
   forall ρ t1 t2,
     valid_interpretation ρ ->
     [ ρ ⊨ t1 : T_nat ] ->
     [ ρ ⊨ t2 : T_nat ] ->
     [ ρ ⊨ binary_primitive Plus t1 t2 : T_nat ].
-Proof. reducible_primitive reducible_values_primitive_plus. Qed.
+Proof. reducible_primitive reducible_values_primitive_Plus. Qed.
 
-Lemma open_reducible_primitive_plus:
+Lemma open_reducible_primitive_Plus:
   forall Θ Γ t1 t2,
     [Θ; Γ ⊨ t1 : T_nat] ->
     [Θ; Γ ⊨ t2 : T_nat] ->
     [Θ; Γ ⊨ binary_primitive Plus t1 t2 : T_nat].
-Proof. unfold open_reducible; steps ; eauto using reducible_primitive_plus. Qed.
+Proof. unfold open_reducible; steps ; eauto using reducible_primitive_Plus. Qed.
 
 (* Minus *)
 
-Lemma reducible_values_primitive_minus:
+
+Lemma reducible_values_primitive_Minus:
   forall ρ v1 v2,
     [ ρ ⊨ v1 : T_nat ]v ->
     [ ρ ⊨ v2 : T_nat ]v ->
     [ binary_primitive Geq v1 v2 ≡ ttrue ] ->
     [ ρ ⊨ binary_primitive Minus v1 v2 : T_nat ].
-Proof. reducible_values_primitive. apply_anywhere equivalent_true. equivalent_binary_primitive. steps. Qed.
+Proof.
+  reducible_values_primitive.
+  apply_anywhere equivalent_true.
+  last_step_binary_primitive.
+Qed.
 
-Lemma reducible_primitive_minus:
+Lemma reducible_primitive_Minus:
   forall ρ t1 t2,
     valid_interpretation ρ ->
     [ ρ ⊨ t1 : T_nat ] ->
     [ ρ ⊨ t2 : T_nat ] ->
     [ binary_primitive Geq t1 t2 ≡ ttrue ] ->
     [ ρ ⊨ binary_primitive Minus t1 t2 : T_nat ].
-Proof. reducible_primitive reducible_values_primitive_minus.
+Proof. reducible_primitive reducible_values_primitive_Minus.
        eapply equivalent_trans; eauto.
        apply equivalent_sym, equivalent_star; eauto with cbvlemmas smallstep wf fv; t_closer.
        apply star_smallstep_binary_primitive; eauto with values.
 Qed.
 
-Lemma open_reducible_primitive_minus:
+Lemma open_reducible_primitive_Minus:
   forall Θ Γ t1 t2,
     [Θ; Γ ⊨ t1 : T_nat] ->
     [Θ; Γ ⊨ t2 : T_nat] ->
     [Θ; Γ ⊨ binary_primitive Geq t1 t2 ≡ ttrue ] ->
     [Θ; Γ ⊨ binary_primitive Minus t1 t2 : T_nat].
 Proof. unfold open_reducible, open_equivalent; steps;
-         eauto using reducible_primitive_minus.
+         eauto using reducible_primitive_Minus.
 Qed.
 
 (* Mul *)
 
-Lemma reducible_values_primitive_mul:
+Lemma reducible_values_primitive_Mul:
   forall ρ v1 v2,
     [ ρ ⊨ v1 : T_nat ]v ->
     [ ρ ⊨ v2 : T_nat ]v ->
     [ ρ ⊨ binary_primitive Mul v1 v2 : T_nat ].
 Proof. reducible_values_primitive. Qed.
 
-Lemma reducible_primitive_mul:
+Lemma reducible_primitive_Mul:
   forall ρ t1 t2,
     valid_interpretation ρ ->
     [ ρ ⊨ t1 : T_nat ] ->
     [ ρ ⊨ t2 : T_nat ] ->
     [ ρ ⊨ binary_primitive Mul t1 t2 : T_nat ].
-Proof. reducible_primitive reducible_values_primitive_mul. Qed.
+Proof. reducible_primitive reducible_values_primitive_Mul. Qed.
 
-Lemma open_reducible_primitive_mul:
+Lemma open_reducible_primitive_Mul:
   forall Θ Γ t1 t2,
     [Θ; Γ ⊨ t1 : T_nat] ->
     [Θ; Γ ⊨ t2 : T_nat] ->
     [Θ; Γ ⊨ binary_primitive Mul t1 t2 : T_nat].
-Proof. unfold open_reducible; steps ; eauto using reducible_primitive_mul. Qed.
+Proof. unfold open_reducible; steps ; eauto using reducible_primitive_Mul. Qed.
 
 (* Div *)
 
-Lemma reducible_values_primitive_div:
+Lemma reducible_values_primitive_Div:
   forall ρ v1 v2 ,
     [ ρ ⊨ v1 : T_nat ]v ->
     [ ρ ⊨ v2 : T_nat ]v ->
     [ binary_primitive Gt v2 zero ≡ ttrue] ->
     [ ρ ⊨ binary_primitive Div v1 v2 : T_nat ].
-Proof. reducible_values_primitive. apply_anywhere equivalent_true. equivalent_binary_primitive. steps. Qed.
+Proof. reducible_values_primitive. apply_anywhere equivalent_true. last_step_binary_primitive. Qed.
 
-Lemma reducible_primitive_div:
+Lemma reducible_primitive_Div:
   forall ρ t1 t2,
     valid_interpretation ρ ->
     [ ρ ⊨ t1 : T_nat ] ->
@@ -131,159 +163,221 @@ Lemma reducible_primitive_div:
     [ binary_primitive Gt t2 zero ≡ ttrue] ->
     [ ρ ⊨ binary_primitive Div t1 t2 : T_nat ].
 Proof.
-  reducible_primitive reducible_values_primitive_div.
+  reducible_primitive reducible_values_primitive_Div.
   eapply equivalent_trans; eauto.
   apply equivalent_sym, equivalent_star; eauto with cbvlemmas smallstep wf fv; t_closer.
 Qed.
 
-Lemma open_reducible_primitive_div:
+Lemma open_reducible_primitive_Div:
   forall Θ Γ t1 t2,
     [Θ; Γ ⊨ t1 : T_nat] ->
     [Θ; Γ ⊨ t2 : T_nat] ->
     [Θ; Γ ⊨ binary_primitive Gt t2 zero ≡ ttrue ] ->
     [Θ; Γ ⊨ binary_primitive Div t1 t2 : T_nat].
-Proof. unfold open_reducible, open_equivalent; steps ; eauto using reducible_primitive_div. Qed.
+Proof. unfold open_reducible, open_equivalent; steps ; eauto using reducible_primitive_Div. Qed.
 
 (* Lt *)
 
-Lemma reducible_values_primitive_lt:
+Lemma reducible_values_primitive_Lt:
   forall ρ v1 v2,
     [ ρ ⊨ v1 : T_nat ]v ->
     [ ρ ⊨ v2 : T_nat ]v ->
     [ ρ ⊨ binary_primitive Lt v1 v2 : T_bool ].
 Proof. reducible_values_primitive. steps. Qed.
 
-Lemma reducible_primitive_lt:
+Lemma reducible_primitive_Lt:
   forall ρ t1 t2,
     valid_interpretation ρ ->
     [ ρ ⊨ t1 : T_nat ] ->
     [ ρ ⊨ t2 : T_nat ] ->
     [ ρ ⊨ binary_primitive Lt t1 t2 : T_bool ].
-Proof. reducible_primitive reducible_values_primitive_lt. Qed.
+Proof. reducible_primitive reducible_values_primitive_Lt. Qed.
 
-Lemma open_reducible_primitive_lt:
+Lemma open_reducible_primitive_Lt:
   forall Θ Γ t1 t2,
     [Θ; Γ ⊨ t1 : T_nat] ->
     [Θ; Γ ⊨ t2 : T_nat] ->
     [Θ; Γ ⊨ binary_primitive Lt t1 t2 : T_bool].
-Proof. unfold open_reducible; steps ; eauto using reducible_primitive_lt. Qed.
+Proof. unfold open_reducible; steps ; eauto using reducible_primitive_Lt. Qed.
 
 (* Leq *)
 
-Lemma reducible_values_primitive_leq:
+Lemma reducible_values_primitive_Leq:
   forall ρ v1 v2,
     [ ρ ⊨ v1 : T_nat ]v ->
     [ ρ ⊨ v2 : T_nat ]v ->
     [ ρ ⊨ binary_primitive Leq v1 v2 : T_bool ].
 Proof. reducible_values_primitive. steps. Qed.
 
-Lemma reducible_primitive_leq:
+Lemma reducible_primitive_Leq:
   forall ρ t1 t2,
     valid_interpretation ρ ->
     [ ρ ⊨ t1 : T_nat ] ->
     [ ρ ⊨ t2 : T_nat ] ->
     [ ρ ⊨ binary_primitive Leq t1 t2 : T_bool ].
-Proof. reducible_primitive reducible_values_primitive_leq. Qed.
+Proof. reducible_primitive reducible_values_primitive_Leq. Qed.
 
-Lemma open_reducible_primitive_leq:
+Lemma open_reducible_primitive_Leq:
   forall Θ Γ t1 t2,
     [Θ; Γ ⊨ t1 : T_nat] ->
     [Θ; Γ ⊨ t2 : T_nat] ->
     [Θ; Γ ⊨ binary_primitive Leq t1 t2 : T_bool].
-Proof. unfold open_reducible; steps ; eauto using reducible_primitive_leq. Qed.
+Proof. unfold open_reducible; steps ; eauto using reducible_primitive_Leq. Qed.
 
 (* Gt *)
 
-Lemma reducible_values_primitive_gt:
+Lemma reducible_values_primitive_Gt:
   forall ρ v1 v2,
     [ ρ ⊨ v1 : T_nat ]v ->
     [ ρ ⊨ v2 : T_nat ]v ->
     [ ρ ⊨ binary_primitive Gt v1 v2 : T_bool ].
 Proof. reducible_values_primitive. steps. Qed.
 
-Lemma reducible_primitive_gt:
+Lemma reducible_primitive_Gt:
   forall ρ t1 t2,
     valid_interpretation ρ ->
     [ ρ ⊨ t1 : T_nat ] ->
     [ ρ ⊨ t2 : T_nat ] ->
     [ ρ ⊨ binary_primitive Gt t1 t2 : T_bool ].
-Proof. reducible_primitive reducible_values_primitive_gt. Qed.
+Proof. reducible_primitive reducible_values_primitive_Gt. Qed.
 
-Lemma open_reducible_primitive_gt:
+Lemma open_reducible_primitive_Gt:
   forall Θ Γ t1 t2,
     [Θ; Γ ⊨ t1 : T_nat] ->
     [Θ; Γ ⊨ t2 : T_nat] ->
     [Θ; Γ ⊨ binary_primitive Gt t1 t2 : T_bool].
-Proof. unfold open_reducible; steps ; eauto using reducible_primitive_gt. Qed.
+Proof. unfold open_reducible; steps ; eauto using reducible_primitive_Gt. Qed.
 
 (* Geq *)
 
-Lemma reducible_values_primitive_geq:
+Lemma reducible_values_primitive_Geq:
   forall ρ v1 v2,
     [ ρ ⊨ v1 : T_nat ]v ->
     [ ρ ⊨ v2 : T_nat ]v ->
     [ ρ ⊨ binary_primitive Geq v1 v2 : T_bool ].
 Proof. reducible_values_primitive. steps. Qed.
 
-Lemma reducible_primitive_geq:
+Lemma reducible_primitive_Geq:
   forall ρ t1 t2,
     valid_interpretation ρ ->
     [ ρ ⊨ t1 : T_nat ] ->
     [ ρ ⊨ t2 : T_nat ] ->
     [ ρ ⊨ binary_primitive Geq t1 t2 : T_bool ].
-Proof. reducible_primitive reducible_values_primitive_geq. Qed.
+Proof. reducible_primitive reducible_values_primitive_Geq. Qed.
 
-Lemma open_reducible_primitive_geq:
+Lemma open_reducible_primitive_Geq:
   forall Θ Γ t1 t2,
     [Θ; Γ ⊨ t1 : T_nat] ->
     [Θ; Γ ⊨ t2 : T_nat] ->
     [Θ; Γ ⊨ binary_primitive Geq t1 t2 : T_bool].
-Proof. unfold open_reducible; steps ; eauto using reducible_primitive_geq. Qed.
+Proof. unfold open_reducible; steps ; eauto using reducible_primitive_Geq. Qed.
 
 (* Eq *)
 
-Lemma reducible_values_primitive_eq:
+Lemma reducible_values_primitive_Eq:
   forall ρ v1 v2,
     [ ρ ⊨ v1 : T_nat ]v ->
     [ ρ ⊨ v2 : T_nat ]v ->
     [ ρ ⊨ binary_primitive Eq v1 v2 : T_bool ].
 Proof. reducible_values_primitive. steps. Qed.
 
-Lemma reducible_primitive_eq:
+Lemma reducible_primitive_Eq:
   forall ρ t1 t2,
     valid_interpretation ρ ->
     [ ρ ⊨ t1 : T_nat ] ->
     [ ρ ⊨ t2 : T_nat ] ->
     [ ρ ⊨ binary_primitive Eq t1 t2 : T_bool ].
-Proof. reducible_primitive reducible_values_primitive_eq. Qed.
+Proof. reducible_primitive reducible_values_primitive_Eq. Qed.
 
-Lemma open_reducible_primitive_eq:
+Lemma open_reducible_primitive_Eq:
   forall Θ Γ t1 t2,
     [Θ; Γ ⊨ t1 : T_nat] ->
     [Θ; Γ ⊨ t2 : T_nat] ->
     [Θ; Γ ⊨ binary_primitive Eq t1 t2 : T_bool].
-Proof. unfold open_reducible; steps ; eauto using reducible_primitive_eq. Qed.
+Proof. unfold open_reducible; steps ; eauto using reducible_primitive_Eq. Qed.
 
 (* Neq *)
 
-Lemma reducible_values_primitive_neq:
+Lemma reducible_values_primitive_Neq:
   forall ρ v1 v2,
     [ ρ ⊨ v1 : T_nat ]v ->
     [ ρ ⊨ v2 : T_nat ]v ->
     [ ρ ⊨ binary_primitive Neq v1 v2 : T_bool ].
 Proof. reducible_values_primitive. steps. Qed.
 
-Lemma reducible_primitive_neq:
+Lemma reducible_primitive_Neq:
   forall ρ t1 t2,
     valid_interpretation ρ ->
     [ ρ ⊨ t1 : T_nat ] ->
     [ ρ ⊨ t2 : T_nat ] ->
     [ ρ ⊨ binary_primitive Neq t1 t2 : T_bool ].
-Proof. reducible_primitive reducible_values_primitive_neq. Qed.
+Proof. reducible_primitive reducible_values_primitive_Neq. Qed.
 
-Lemma open_reducible_primitive_neq:
+Lemma open_reducible_primitive_Neq:
   forall Θ Γ t1 t2,
     [Θ; Γ ⊨ t1 : T_nat] ->
     [Θ; Γ ⊨ t2 : T_nat] ->
     [Θ; Γ ⊨ binary_primitive Neq t1 t2 : T_bool].
-Proof. unfold open_reducible; steps ; eauto using reducible_primitive_neq. Qed.
+Proof. unfold open_reducible; steps ; eauto using reducible_primitive_Neq. Qed.
+
+(* And *)
+
+Lemma reducible_values_primitive_And:
+  forall ρ v1 v2,
+    [ ρ ⊨ v1 : T_bool ]v ->
+    [ ρ ⊨ v2 : T_bool ]v ->
+    [ ρ ⊨ binary_primitive And v1 v2 : T_bool ].
+Proof. reducible_values_primitive. Qed.
+
+Lemma reducible_primitive_And:
+  forall ρ t1 t2,
+    valid_interpretation ρ ->
+    [ ρ ⊨ t1 : T_bool ] ->
+    [ ρ ⊨ t2 : T_bool ] ->
+    [ ρ ⊨ binary_primitive And t1 t2 : T_bool ].
+Proof. reducible_primitive reducible_values_primitive_And. Qed.
+
+Lemma open_reducible_primitive_And:
+  forall Θ Γ t1 t2,
+    [Θ; Γ ⊨ t1 : T_bool] ->
+    [Θ; Γ ⊨ t2 : T_bool] ->
+    [Θ; Γ ⊨ binary_primitive And t1 t2 : T_bool].
+Proof. unfold open_reducible; steps ; eauto using reducible_primitive_And. Qed.
+
+(* Or *)
+
+Lemma reducible_values_primitive_Or:
+  forall ρ v1 v2,
+    [ ρ ⊨ v1 : T_bool ]v ->
+    [ ρ ⊨ v2 : T_bool ]v ->
+    [ ρ ⊨ binary_primitive Or v1 v2 : T_bool ].
+Proof. reducible_values_primitive. Qed.
+
+Lemma reducible_primitive_Or:
+  forall ρ t1 t2,
+    valid_interpretation ρ ->
+    [ ρ ⊨ t1 : T_bool ] ->
+    [ ρ ⊨ t2 : T_bool ] ->
+    [ ρ ⊨ binary_primitive Or t1 t2 : T_bool ].
+Proof. reducible_primitive reducible_values_primitive_Or. Qed.
+
+Lemma open_reducible_primitive_Or:
+  forall Θ Γ t1 t2,
+    [Θ; Γ ⊨ t1 : T_bool] ->
+    [Θ; Γ ⊨ t2 : T_bool] ->
+    [Θ; Γ ⊨ binary_primitive Or t1 t2 : T_bool].
+Proof. unfold open_reducible; steps ; eauto using reducible_primitive_Or. Qed.
+
+
+Hint Resolve open_reducible_primitive_And: primitives.
+Hint Resolve open_reducible_primitive_Div: primitives.
+Hint Resolve open_reducible_primitive_Eq: primitives.
+Hint Resolve open_reducible_primitive_Geq: primitives.
+Hint Resolve open_reducible_primitive_Gt: primitives.
+Hint Resolve open_reducible_primitive_Leq: primitives.
+Hint Resolve open_reducible_primitive_Lt: primitives.
+Hint Resolve open_reducible_primitive_Minus: primitives.
+Hint Resolve open_reducible_primitive_Mul: primitives.
+Hint Resolve open_reducible_primitive_Neq: primitives.
+Hint Resolve open_reducible_primitive_Or: primitives.
+Hint Resolve open_reducible_primitive_Plus: primitives.

--- a/ErasedRec.v
+++ b/ErasedRec.v
@@ -5,7 +5,7 @@ Require Import Coq.Lists.List.
 
 Require Export SystemFR.ReducibilitySubst.
 Require Export SystemFR.SomeTerms.
-Require Export SystemFR.NatLessThan.
+Require Export SystemFR.ErasedPrimitive.
 
 Opaque reducible_values.
 Opaque makeFresh.
@@ -623,17 +623,16 @@ Proof.
       t_closer.
 Qed.
 
+
 Lemma equivalent_zero_contradiction:
   forall n,
-    [ tlt zero n ≡ ttrue ] ->
+    [ binary_primitive Lt zero n ≡ ttrue ] ->
     n ~>* zero ->
     False.
 Proof.
   intros.
-  apply (equivalent_tlt_terms_trans _ _ zero zero) in H;
-    steps.
-  apply equivalent_true in H.
-  apply tlt_sound in H; steps; eauto with lia.
+  apply_anywhere equivalent_true.
+  repeat steps || t_deterministic_star || t_invert_star; eauto with values.
 Qed.
 
 Lemma reducible_unfold_pos_in:
@@ -656,7 +655,7 @@ Lemma reducible_unfold_pos_in:
     pfv n term_var = nil ->
     pfv T0 term_var = nil ->
     pfv Ts term_var = nil ->
-    [ tlt zero n ≡ ttrue ] ->
+    [ binary_primitive Lt zero n ≡ ttrue ] ->
     (forall v,
         [ ρ ⊨ v : topen 0 Ts (T_rec (notype_tpred n) T0 Ts) ]v ->
         [ t1 ≡ v ] ->
@@ -739,7 +738,7 @@ Lemma open_reducible_unfold_pos_in:
       valid_interpretation ρ ->
       satisfies (reducible_values ρ) Γ l ->
       support ρ = Θ ->
-      [ substitute (tlt zero n) l ≡ ttrue ]) ->
+      [ substitute (binary_primitive Lt zero n) l ≡ ttrue ]) ->
     [ Θ;
         (p1, T_equiv t1 (fvar y term_var)) ::
         (y, topen 0 Ts (T_rec (notype_tpred n) T0 Ts)) ::

--- a/ErasedRefine.v
+++ b/ErasedRefine.v
@@ -4,7 +4,6 @@ Require Import Coq.Arith.PeanoNat.
 Require Import Coq.Lists.List.
 
 Require Export SystemFR.ErasedLet2.
-Require Export SystemFR.NatLessThan.
 
 Opaque reducible_values.
 Opaque makeFresh.

--- a/Evaluator.v
+++ b/Evaluator.v
@@ -30,104 +30,216 @@ Fixpoint is_value (t: tree) : bool :=
     | notype_lambda _ => true
     | _ => false end.
 
+Lemma is_value_correct : forall v, is_value v = true <-> cbv_value v.
+Proof.
+  split.
+  - induction v; repeat step || bools; eauto with values.
+  - induction 1; repeat step || bools.
+Defined.
+
+
 Definition get_pair t : {t': option (tree*tree) | forall t1 t2, t' = Some (t1, t2) <-> t = pp t1 t2}.
-  Proof.
-    exists ( match t with
-    | pp e1 e2 => Some (e1,e2)
-    | _ => None end).
-    destruct t; steps.
-  Defined.
+Proof.
+  exists ( match t with
+      | pp e1 e2 => Some (e1,e2)
+      | _ => None end).
+  destruct t; steps.
+Defined.
 
-  Definition get_app t : {t': option tree | forall t1, t' = Some t1 <-> t = notype_lambda t1}.
-  Proof.
-    exists (match t with
-       | notype_lambda body => Some body
-       | _ => None end).
-    destruct t; steps.
-  Defined.
+Definition get_app t : {t': option tree | forall t1, t' = Some t1 <-> t = notype_lambda t1}.
+Proof.
+  exists (match t with
+     | notype_lambda body => Some body
+     | _ => None end).
+  destruct t; steps.
+Defined.
 
-  Definition get_LR t : {t': option tree | forall t1, t' = Some t1 <-> (t = tleft t1 \/ t = tright t1)}.
-  Proof.
-    exists (match t with
-       | tleft t' => Some t'
-       | tright t' => Some t'
-       | _ => None end).
-    destruct t; steps.
-  Defined.
+Definition get_LR t : {t': option tree | forall t1, t' = Some t1 <-> (t = tleft t1 \/ t = tright t1)}.
+Proof.
+  exists (match t with
+     | tleft t' => Some t'
+     | tright t' => Some t'
+     | _ => None end).
+  destruct t; steps.
+Defined.
+
+Fixpoint get_nat t :=
+  match t with
+  | zero => Some 0
+  | succ t => option_map S (get_nat t)
+  | _ => None
+  end.
+
+Lemma get_nat_build_nat :
+  forall n, get_nat (build_nat n) = Some n.
+Proof.
+  induction n; repeat steps || rewrite_any.
+Qed.
+
+Lemma get_nat_prop :
+  forall t n, get_nat t = Some n -> t = build_nat n.
+Proof.
+  induction t; steps.
+  destruct n; unfold option_map in *; steps.
+Qed.
+
+
+Definition ss_eval_binary_primitive (o:op) t1 t2 :=
+  match (get_nat t1), (get_nat t2) with
+  | (Some n1), (Some n2) => (
+      match o with
+      | Eq => Some (if (PeanoNat.Nat.eqb n1 n2) then ttrue else tfalse)
+      | Neq => Some (if (PeanoNat.Nat.eqb n1 n2) then tfalse else ttrue)
+      | Plus => Some (build_nat (n1 + n2))
+      | Minus => if (PeanoNat.Nat.leb n2 n1) then
+                  Some (build_nat (Nat.sub n1 n2))
+                else None
+      | Mul => Some (build_nat (n1 * n2))
+      | Div => if (PeanoNat.Nat.ltb 0 n2) then
+                Some (build_nat (PeanoNat.Nat.div n1 n2))
+              else None
+      | Lt => Some (if (PeanoNat.Nat.ltb n1 n2) then ttrue else tfalse)
+      | Leq => Some (if (PeanoNat.Nat.leb n1 n2) then ttrue else tfalse)
+      | Gt => Some (if (PeanoNat.Nat.leb n1 n2) then tfalse else ttrue)
+      | Geq => Some (if (PeanoNat.Nat.ltb n1 n2) then tfalse else ttrue)
+      | And | Or | Not | Cup | Nop => None  end)
+  | _, _ => match o,t1,t2 with
+           | And, ttrue, ttrue => Some ttrue
+           | And, ttrue, tfalse => Some tfalse
+           | And, tfalse, ttrue => Some tfalse
+           | And, tfalse, tfalse => Some tfalse
+           | Or, ttrue, ttrue => Some ttrue
+           | Or, ttrue, tfalse => Some ttrue
+           | Or, tfalse, ttrue => Some ttrue
+           | Or, tfalse, tfalse => Some tfalse
+           | _,_,_ => None end
+  end.
+
+Opaque PeanoNat.Nat.leb.
+Opaque PeanoNat.Nat.ltb.
+
+Ltac natb_rewrites :=
+  repeat rewrite PeanoNat.Nat.leb_le in * || rewrite PeanoNat.Nat.ltb_lt in * || rewrite PeanoNat.Nat.eqb_eq in * || rewrite PeanoNat.Nat.eqb_neq in * || rewrite PeanoNat.Nat.ltb_nlt in * || rewrite PeanoNat.Nat.leb_nle in *.
+
+Lemma ss_eval_binary_primitive_prop :
+  forall o t1 t2 t,
+    cbv_value t1 ->
+    cbv_value t2 ->
+    ss_eval_binary_primitive o t1 t2 = Some t <-> scbv_step (binary_primitive o t1 t2) t.
+Proof.
+  split; intros.
+  + unfold ss_eval_binary_primitive in *; steps;
+      repeat apply_anywhere get_nat_prop ; subst ;
+        eapply scbv_step_same; try constructor ; repeat steps || natb_rewrites.
+  + t_invert_step; steps.
+    all: try solve [
+               unfold ss_eval_binary_primitive;
+               repeat rewrite get_nat_build_nat in * || natb_rewrites || steps] .
+    all: try solve [
+               exfalso;
+               eauto using evaluate_step ].
+Qed.
+
+Lemma ss_eval_binary_primitive_prop2 :
+  forall o t1 t2 t,
+    is_value t1 = true ->
+    is_value t2 = true ->
+    ss_eval_binary_primitive o t1 t2 = Some t <-> scbv_step (binary_primitive o t1 t2) t.
+Proof.
+  intros. repeat rewrite is_value_correct in *. eauto using ss_eval_binary_primitive_prop.
+Qed.
 
 
 (* Evaluator (smallstep) *)
 Fixpoint ss_eval (t: tree) {struct t}: (option tree) :=
   match t with
-    | ite ttrue t1 t2 => Some t1
-    | ite tfalse t1 t2 => Some t2
-    | ite t t1 t2 => option_map (fun e => ite e t1 t2) (ss_eval t)
+  | ite ttrue t1 t2 => Some t1
+  | ite tfalse t1 t2 => Some t2
+  | ite t t1 t2 => option_map (fun e => ite e t1 t2) (ss_eval t)
 
-    | pp e1 e2 => match (is_value e1) with
-                   | true => option_map (pp e1) (ss_eval e2)
-                   | false => option_map (fun e => pp e e2) (ss_eval e1) end
+  | pp e1 e2 => match (is_value e1) with
+               | true => option_map (pp e1) (ss_eval e2)
+               | false => option_map (fun e => pp e e2) (ss_eval e1) end
 
-    | pi1 t => match get_pair t with
-              | exist _ None _  => option_map pi1 (ss_eval t)
-              | exist _ (Some (e1, e2)) _ =>
-                if (is_value e1) && (is_value e2)
-                then Some e1
-                else option_map pi1 (ss_eval t) end
+  | pi1 t => match get_pair t with
+            | exist _ None _  => option_map pi1 (ss_eval t)
+            | exist _ (Some (e1, e2)) _ =>
+              if (is_value e1) && (is_value e2)
+              then Some e1
+              else option_map pi1 (ss_eval t) end
 
-    | pi2 t => match get_pair t with
-              | exist _ None _ => option_map pi2 (ss_eval t)
-              | exist _ (Some (e1, e2)) _ =>
-                if (is_value e1) && (is_value e2)
-                then Some e2
-                else option_map pi2 (ss_eval t) end
+  | pi2 t => match get_pair t with
+            | exist _ None _ => option_map pi2 (ss_eval t)
+            | exist _ (Some (e1, e2)) _ =>
+              if (is_value e1) && (is_value e2)
+              then Some e2
+              else option_map pi2 (ss_eval t) end
 
-    | app t1 t2 => match (is_value t1) with
-                    | true => match get_app t1 with
-                             | exist _ None _ => option_map (app t1) (ss_eval t2)
-                             | exist _ (Some ts) _ =>
-                               if (is_value t2)
-                               then Some (open 0 ts t2)
-                               else option_map (app t1) (ss_eval t2) end
-                    | false => option_map (fun e => app e t2) (ss_eval t1) end
+  | app t1 t2 => match (is_value t1) with
+                | true => match get_app t1 with
+                         | exist _ None _ => option_map (app t1) (ss_eval t2)
+                         | exist _ (Some ts) _ =>
+                           if (is_value t2)
+                           then Some (open 0 ts t2)
+                           else option_map (app t1) (ss_eval t2) end
+                | false => option_map (fun e => app e t2) (ss_eval t1) end
 
-    | notype_tfix ts => Some (open 0 (open 1 ts zero) (notype_tfix ts))
+  | notype_tfix ts => Some (open 0 (open 1 ts zero) (notype_tfix ts))
 
-    | succ t => option_map succ (ss_eval t)
+  | succ t => option_map succ (ss_eval t)
 
-    | tmatch t1 t0 ts => match t1 with
-                       | zero => Some t0
-                       | succ t2 =>
-                         if (is_value t2)
-                         then Some (open 0 ts t2)
-                         else option_map (fun e => tmatch e t0 ts) (ss_eval t1)
-                       | _ => option_map (fun e => tmatch e t0 ts) (ss_eval t1) end
+  | tmatch t1 t0 ts => match t1 with
+                      | zero => Some t0
+                      | succ t2 =>
+                        if (is_value t2)
+                        then Some (open 0 ts t2)
+                        else option_map (fun e => tmatch e t0 ts) (ss_eval t1)
+                      | _ => option_map (fun e => tmatch e t0 ts) (ss_eval t1) end
 
-    | sum_match t tl tr => if (is_value t) then match t with
-                                   | tleft v => Some (open 0 tl v)
-                                   | tright v => Some (open 0 tr v)
+  | sum_match t tl tr => if (is_value t) then match t with
+                                             | tleft v => Some (open 0 tl v)
+                                             | tright v => Some (open 0 tr v)
+                                             | _ => None end
+                        else option_map (fun e => sum_match e tl tr) (ss_eval t)
+
+  | tleft t => option_map tleft (ss_eval t)
+  | tright t => option_map tright (ss_eval t)
+
+  | tsize t => if (is_value t) then Some (build_nat (tsize_semantics t)) else (option_map tsize (ss_eval t))
+  | boolean_recognizer r t => if (is_value t) then match r with
+                                                  | 0 => Some (is_pair t)
+                                                  | 1 => Some (is_succ t)
+                                                  | 2 => Some (is_lambda t)
+                                                  | _ => None end
+                             else option_map (boolean_recognizer r) (ss_eval t)
+
+  | unary_primitive o t => match (is_value t) with
+                          | false => option_map (unary_primitive o) (ss_eval t)
+                          | true => match o with
+                                   | Not => match t with
+                                           | ttrue => Some (tfalse)
+                                           | tfalse => Some (ttrue)
+                                           | _ => None end
                                    | _ => None end
-                          else option_map (fun e => sum_match e tl tr) (ss_eval t)
+                          end
 
-    | tleft t => option_map tleft (ss_eval t)
-    | tright t => option_map tright (ss_eval t)
+  | binary_primitive o t1 t2 => match (is_value t1) with
+                               | false => option_map (fun e => binary_primitive o e t2) (ss_eval t1)
+                               | true => match (is_value t2) with
+                                        | false => option_map (binary_primitive o t1) (ss_eval t2)
+                                        | true => ss_eval_binary_primitive o t1 t2 end
+                               end
 
-    | tsize t => if (is_value t) then Some (build_nat (tsize_semantics t)) else (option_map tsize (ss_eval t))
-    | boolean_recognizer r t => if (is_value t) then match r with
-                                                   | 0 => Some (is_pair t)
-                                                   | 1 => Some (is_succ t)
-                                                   | 2 => Some (is_lambda t)
-                                                   | _ => None end
-                               else option_map (boolean_recognizer r) (ss_eval t)
-    | _ => None
+  | _ => None
   end.
 
 (* Compute a certain number of small steps *)
 Fixpoint ss_eval_n (t : tree) (k: nat) : (option tree) :=
   match k with
-    | 0 => Some t
-    | S k' => match ss_eval t with
-               | Some t' => ss_eval_n t' k'
-               | None => Some t end
+  | 0 => Some t
+  | S k' => match ss_eval t with
+           | Some t' => ss_eval_n t' k'
+           | None => Some t end
   end.
 
 (* Entry point for evaluation *)
@@ -137,7 +249,7 @@ Definition eval (t: tree) (k: nat): (option tree) :=
 
 (* Tactics *)
 Ltac destruct_sig :=
-match goal with
+  match goal with
   | H: _ |- context[let _ := get_pair ?t in _ ]  =>
     let fresh := fresh "get_pair" in destruct (get_pair t) (* eqn:fresh *)
   | H: context[get_pair ?t = _ ] |- _ =>
@@ -148,21 +260,14 @@ match goal with
     let fresh := fresh "get_app" in destruct (get_app t) (* eqn:fresh *)
   | H: context[_ = get_app ?t ] |- _ =>
     let fresh := fresh "get_app" in destruct (get_app t) (* eqn:fresh *)
-end. (* match on type of t = sig *)
+  end. (* match on type of t = sig *)
 
 Ltac destruct_ss_eval :=
   match goal with
-    | H: context[ss_eval ?t] |- _ => destruct (ss_eval t) end.
+  | H: context[ss_eval ?t] |- _ => destruct (ss_eval t) end.
 
 
 (* Results *)
-Lemma is_value_correct : forall v, is_value v = true <-> cbv_value v.
-Proof.
-  split.
-  - induction v; repeat step || bools; eauto with values.
-  - induction 1; repeat step || bools.
-Defined.
-
 Lemma ss_eval_step : forall t t', ss_eval t = Some t' -> is_value t = true -> False.
 Proof.
   induction t; repeat step || options.
@@ -173,26 +278,59 @@ Ltac ss_eval_step :=
   |H: ss_eval ?t1 = Some ?t2 |- _ => poseNew (Mark (t1, t2) "ss_eval_step_h");
                                    pose proof  (ss_eval_step _ _ H) end.
 
+Lemma is_value_build_nat_false:
+  forall n,
+    is_value (build_nat n) = false -> False.
+Proof.
+  intros.
+  assert (is_value (build_nat n) = true ). rewrite is_value_correct; eauto with values.
+  steps.
+Qed.
+
+Ltac is_value_build_nat_false :=
+  match goal with
+  |H: is_value (build_nat ?n) = false |- _ => exfalso; apply (is_value_build_nat_false n H)
+  end.
 
 Lemma ss_eval_correct2: forall t t',
-  pfv t term_var = nil ->
-  t ~> t' ->
-  ss_eval t = Some t'.
+    pfv t term_var = nil ->
+    t ~> t' ->
+    ss_eval t = Some t'.
 Proof.
-  intros. induction H0 ; repeat light || options || invert_constructor_equalities || ss_eval_step || destruct_sig || instantiate_eq_refl || list_utils || bools || rewrite <- is_value_correct in * ||  eauto using fv_nil_top_level_var with smallstep values || destruct_match.
+  intros.
+  induction H0 ;
+    repeat light || options || invert_constructor_equalities
+    || ss_eval_step || destruct_sig || instantiate_eq_refl
+    || list_utils || bools
+    || (rewrite <- is_value_correct in * )
+    || (rewrite get_nat_build_nat in * )
+    || natb_rewrites
+    || is_value_build_nat_false
+    || (eauto using ss_eval_binary_primitive_prop2, fv_nil_top_level_var with smallstep values)
+    || destruct_match || unfold ss_eval_binary_primitive.
 Qed.
 
 Lemma ss_eval_correct1: forall t t',
-  ss_eval t = Some t' ->
-  pfv t term_var = nil ->
-  t ~> t'.
+    ss_eval t = Some t' ->
+    pfv t term_var = nil ->
+    t ~> t'.
 Proof.
-  induction t; intros ; repeat light ; destruct_ss_eval ; repeat light || options || bools || list_utils || instantiate_eq_refl || invert_constructor_equalities || rewrite is_value_correct in * || destruct_sig || congruence ||  step_inversion cbv_value || destruct_match ; eauto using ss_eval_step, fv_nil_top_level_var with smallstep values.
+  induction t;
+    intros ;
+    repeat light ; destruct_ss_eval ;
+      repeat light || options || bools
+      || list_utils || instantiate_eq_refl || invert_constructor_equalities
+      || (rewrite is_value_correct in *)
+         || destruct_sig || congruence
+         ||  step_inversion cbv_value || destruct_match ;
+         eauto using ss_eval_binary_primitive_prop2, ss_eval_step, fv_nil_top_level_var with smallstep values.
+         all: try solve [
+                    apply ss_eval_binary_primitive_prop; eauto ].
 Qed.
 
 (* Main theorem : the evaluator corresponds to the small call-by-value steps *)
 Theorem ss_eval_correct : forall t t',
-  pfv t term_var = nil ->
+    pfv t term_var = nil ->
     ss_eval t = Some t' <-> t ~> t'.
 Proof.
   split; eauto using ss_eval_correct1, ss_eval_correct2.
@@ -206,4 +344,4 @@ Extraction Language Ocaml.
 Set Extraction AccessOpaque.
 
 Extraction "evaluator.ml" eval.
-*)
+ *)

--- a/PrimitiveRecognizers.v
+++ b/PrimitiveRecognizers.v
@@ -17,3 +17,15 @@ Definition is_lambda (v: tree): tree :=
   | notype_lambda _ => ttrue
   | _ => tfalse
   end.
+
+Definition is_unary_primitive (v: tree): tree :=
+  match v with
+  | unary_primitive _ _ => ttrue
+  | _ => tfalse
+  end.
+
+Definition is_binary_primitive (v: tree): tree :=
+  match v with
+  | binary_primitive _ _ _ => ttrue
+  | _ => tfalse
+  end.

--- a/ShiftOpen.v
+++ b/ShiftOpen.v
@@ -43,6 +43,9 @@ Fixpoint shift (k: nat) (t: tree) (i: nat) :=
           (shift k t1 i)
           (shift (S k) t2 i)
 
+  | unary_primitive o t => unary_primitive o (shift k t i)
+  | binary_primitive o t1 t2 => binary_primitive o (shift k t1 i) (shift k t2 i)
+
   | tfix T t' => tfix (shift (S k) T i) (shift (S (S k)) t' i)
   | notype_tfix t' => notype_tfix (shift (S (S k)) t' i)
 
@@ -122,6 +125,9 @@ Fixpoint shift_open (k: nat) (t rep: tree) :=
           (shift_open k t' rep)
           (shift_open k t1 rep)
           (shift_open (S k) t2 (shift 0 rep 1))
+
+  | unary_primitive o t => unary_primitive o (shift_open k t rep)
+  | binary_primitive o t1 t2 => binary_primitive o (shift_open k t1 rep) (shift_open k t2 rep)
 
   | tfix T t' => tfix (shift_open (S k) T (shift 0 rep 1)) (shift_open (S (S k)) t' (shift 0 rep 2))
   | notype_tfix t' => notype_tfix (shift_open (S (S k)) t' (shift 0 rep 2))

--- a/SmallStep.v
+++ b/SmallStep.v
@@ -40,6 +40,7 @@ Ltac cbv_value t :=
         | notype_lambda _ => idtac
         | tleft ?v => cbv_value v
         | tright ?v => cbv_value v
+        | build_nat ?n => idtac
         end
   end.
 
@@ -208,6 +209,7 @@ Inductive scbv_step: tree -> tree -> Prop :=
 | SPBetaMinus: forall v1 v2 n1 n2,
     v1 = build_nat n1 ->
     v2 = build_nat n2 ->
+    n1 >= n2 ->
     scbv_step (binary_primitive Minus v1 v2) (build_nat (n1 - n2))
 | SPBetaMul: forall v1 v2 n1 n2,
     v1 = build_nat n1 ->
@@ -215,7 +217,8 @@ Inductive scbv_step: tree -> tree -> Prop :=
     scbv_step (binary_primitive Mul v1 v2) (build_nat (n1 * n2))
 | SPBetaDiv: forall v1 v2 n1 n2,
     v1 = build_nat n1 ->
-    v2 = build_nat (S n2) ->
+    v2 = build_nat n2 ->
+    n2 > 0 ->
     scbv_step (binary_primitive Div v1 v2) (build_nat (PeanoNat.Nat.div n1 (S n2)))
 | SPBetaEq: forall v1 v2 n1 n2,
     v1 = build_nat n1 ->

--- a/SmallStep.v
+++ b/SmallStep.v
@@ -247,10 +247,13 @@ Inductive scbv_step: tree -> tree -> Prop :=
 
 | SPBetaAnd1: scbv_step (binary_primitive And ttrue ttrue) ttrue
 | SPBetaAnd2: scbv_step (binary_primitive And ttrue tfalse) tfalse
+| SPBetaAnd3: scbv_step (binary_primitive And tfalse ttrue) tfalse
+| SPBetaAnd4: scbv_step (binary_primitive And tfalse tfalse) tfalse
 
 | SPBetaOr1: scbv_step (binary_primitive Or tfalse tfalse) tfalse
 | SPBetaOr2: scbv_step (binary_primitive Or tfalse ttrue) ttrue
-
+| SPBetaOr3: scbv_step (binary_primitive Or ttrue tfalse) ttrue
+| SPBetaOr4: scbv_step (binary_primitive Or ttrue ttrue) ttrue
 
 (* reduction inside terms *)
 | SPAppLeft: forall t1 t2 t,

--- a/SmallStep.v
+++ b/SmallStep.v
@@ -219,7 +219,7 @@ Inductive scbv_step: tree -> tree -> Prop :=
     v1 = build_nat n1 ->
     v2 = build_nat n2 ->
     n2 > 0 ->
-    scbv_step (binary_primitive Div v1 v2) (build_nat (PeanoNat.Nat.div n1 (S n2)))
+    scbv_step (binary_primitive Div v1 v2) (build_nat (PeanoNat.Nat.div n1 n2))
 | SPBetaEq: forall v1 v2 n1 n2,
     v1 = build_nat n1 ->
     v2 = build_nat n2 ->

--- a/SmallStep.v
+++ b/SmallStep.v
@@ -204,43 +204,43 @@ Inductive scbv_step: tree -> tree -> Prop :=
 | SPBetaPlus: forall v1 v2 n1 n2,
     v1 = build_nat n1 ->
     v2 = build_nat n2 ->
-    scbv_step (binary_primitive plus v1 v2) (build_nat (n1 + n2))
+    scbv_step (binary_primitive Plus v1 v2) (build_nat (n1 + n2))
 | SPBetaMinus: forall v1 v2 n1 n2,
     v1 = build_nat n1 ->
     v2 = build_nat n2 ->
-    scbv_step (binary_primitive minus v1 v2) (build_nat (n1 - n2))
+    scbv_step (binary_primitive Minus v1 v2) (build_nat (n1 - n2))
 | SPBetaMul: forall v1 v2 n1 n2,
     v1 = build_nat n1 ->
     v2 = build_nat n2 ->
-    scbv_step (binary_primitive mul v1 v2) (build_nat (n1 * n2))
+    scbv_step (binary_primitive Mul v1 v2) (build_nat (n1 * n2))
 | SPBetaDiv: forall v1 v2 n1 n2,
     v1 = build_nat n1 ->
     v2 = build_nat (S n2) ->
-    scbv_step (binary_primitive div v1 v2) (build_nat (PeanoNat.Nat.div n1 (S n2)))
+    scbv_step (binary_primitive Div v1 v2) (build_nat (PeanoNat.Nat.div n1 (S n2)))
 | SPBetaEq: forall v1 v2 n1 n2,
     v1 = build_nat n1 ->
     v2 = build_nat n2 ->
-    scbv_step (binary_primitive eq  v1 v2) (if PeanoNat.Nat.eqb n1 n2 then ttrue else tfalse)
+    scbv_step (binary_primitive Eq  v1 v2) (if PeanoNat.Nat.eqb n1 n2 then ttrue else tfalse)
 | SPBetaNeq: forall v1 v2 n1 n2,
     v1 = build_nat n1 ->
     v2 = build_nat n2 ->
-    scbv_step (binary_primitive neq v1 v2) (if (PeanoNat.Nat.eq_dec n1 n2) then tfalse else ttrue)
+    scbv_step (binary_primitive Neq v1 v2) (if (PeanoNat.Nat.eq_dec n1 n2) then tfalse else ttrue)
 | SPBetaLt: forall v1 v2 n1 n2,
     v1 = build_nat n1 ->
     v2 = build_nat n2 ->
-    scbv_step (binary_primitive lt  v1 v2) (if PeanoNat.Nat.ltb n1 n2 then ttrue else tfalse)
+    scbv_step (binary_primitive Lt  v1 v2) (if PeanoNat.Nat.ltb n1 n2 then ttrue else tfalse)
 | SPBetaLeq: forall v1 v2 n1 n2,
     v1 = build_nat n1 ->
     v2 = build_nat n2 ->
-    scbv_step (binary_primitive leq v1 v2) (if PeanoNat.Nat.leb n1 n2 then ttrue else tfalse)
+    scbv_step (binary_primitive Leq v1 v2) (if PeanoNat.Nat.leb n1 n2 then ttrue else tfalse)
 | SPBetaGt: forall v1 v2 n1 n2,
     v1 = build_nat n1 ->
     v2 = build_nat n2 ->
-    scbv_step (binary_primitive gt  v1 v2) (if PeanoNat.Nat.leb n1 n2 then tfalse else ttrue)
+    scbv_step (binary_primitive Gt  v1 v2) (if PeanoNat.Nat.leb n1 n2 then tfalse else ttrue)
 | SPBetaGeq: forall v1 v2 n1 n2,
     v1 = build_nat n1 ->
     v2 = build_nat n2 ->
-    scbv_step (binary_primitive geq v1 v2) (if PeanoNat.Nat.ltb n1 n2 then tfalse else ttrue)
+    scbv_step (binary_primitive Geq v1 v2) (if PeanoNat.Nat.ltb n1 n2 then tfalse else ttrue)
 
 | SPBetaNot1: scbv_step (unary_primitive Not ttrue) tfalse
 | SPBetaNot2: scbv_step (unary_primitive Not tfalse) ttrue

--- a/StarInversions.v
+++ b/StarInversions.v
@@ -140,6 +140,44 @@ Proof.
   - exists v1; steps; eauto with values smallstep star.
 Qed.
 
+Lemma star_smallstep_unary_primitive_inv:
+  forall t v,
+    star scbv_step t v ->
+    cbv_value v ->
+    forall t' o,
+      t = unary_primitive o t' ->
+      exists v1,
+        cbv_value v1 /\ star scbv_step t' v1.
+Proof.
+  induction 1; repeat step || step_inversion cbv_value || t_invert_step; eauto with cbvlemmas.
+  exists ttrue; steps.
+  exists tfalse; steps.
+  exists v1; steps; eauto with values smallstep star cbvlemmas.
+Qed.
+
+Lemma star_smallstep_binary_primitive_inv:
+  forall t v,
+    star scbv_step t v ->
+    cbv_value v ->
+    forall t1 t2 o,
+      t = binary_primitive o t1 t2 ->
+      exists v1 v2,
+        cbv_value v1 /\ star scbv_step t1 v1 /\ cbv_value v2 /\ star scbv_step t2 v2.
+Proof.
+  induction 1; repeat steps || step_inversion cbv_value || t_invert_step; eauto with cbvlemmas star smallstep.
+  all: try solve [exists (build_nat n1), (build_nat n2); steps; eauto with values smallstep star cbvlemmas].
+  all: try solve [exists (build_nat n1), (succ (build_nat n2)); steps; eauto with values smallstep star cbvlemmas].
+  all: try solve [exists (build_nat n2), (build_nat n2); steps; eauto with values smallstep star cbvlemmas].
+  all: try solve [exists (build_nat n1), (succ (build_nat n)); steps; eauto with values smallstep star cbvlemmas].
+  all: try solve [exists (build_nat n1), zero; steps; eauto with values smallstep star cbvlemmas].
+  all: try solve [exists ttrue, ttrue; steps; eauto with values smallstep star cbvlemmas].
+  all: try solve [exists ttrue, tfalse; steps; eauto with values smallstep star cbvlemmas].
+  all: try solve [exists tfalse, ttrue; steps; eauto with values smallstep star cbvlemmas].
+  all: try solve [exists tfalse, tfalse; steps; eauto with values smallstep star cbvlemmas].
+  all: try solve [exists v1, v2; steps; eauto with values smallstep star cbvlemmas].
+Qed.
+
+
 Lemma star_smallstep_ite_inv:
   forall t v,
     t ~>* v ->

--- a/StarInversions.v
+++ b/StarInversions.v
@@ -142,12 +142,12 @@ Qed.
 
 Lemma star_smallstep_unary_primitive_inv:
   forall t v,
-    star scbv_step t v ->
+    t ~>* v ->
     cbv_value v ->
     forall t' o,
       t = unary_primitive o t' ->
       exists v1,
-        cbv_value v1 /\ star scbv_step t' v1.
+        cbv_value v1 /\ t' ~>* v1.
 Proof.
   induction 1; repeat step || step_inversion cbv_value || t_invert_step; eauto with cbvlemmas.
   exists ttrue; steps.
@@ -157,12 +157,12 @@ Qed.
 
 Lemma star_smallstep_binary_primitive_inv:
   forall t v,
-    star scbv_step t v ->
+    t ~>* v ->
     cbv_value v ->
     forall t1 t2 o,
       t = binary_primitive o t1 t2 ->
       exists v1 v2,
-        cbv_value v1 /\ star scbv_step t1 v1 /\ cbv_value v2 /\ star scbv_step t2 v2.
+        cbv_value v1 /\ t1 ~>* v1 /\ cbv_value v2 /\ t2 ~>* v2.
 Proof.
   induction 1; repeat steps || step_inversion cbv_value || t_invert_step; eauto with cbvlemmas star smallstep.
   all: try solve [exists (build_nat n1), (build_nat n2); steps; eauto with values smallstep star cbvlemmas].
@@ -454,6 +454,12 @@ Ltac t_invert_star :=
     (not_cbv_value t1 || not_cbv_value t2);
     poseNew (Mark H2 "inv pair");
     unshelve epose proof (star_smallstep_pp_inv _ v H2 _ t1 t2 eq_refl)
+
+  | H2: binary_primitive ?o ?t1 ?t2 ~>* ?v |- _ =>
+    cbv_value v;
+    (not_cbv_value t1 || not_cbv_value t2);
+    poseNew (Mark H2 "inv binary primitive");
+    unshelve epose proof (star_smallstep_binary_primitive_inv _ v H2 _ t1 t2 o eq_refl)
 
   | H2: pi1 ?t ~>* ?v |- _ =>
     cbv_value v;

--- a/StarLemmas.v
+++ b/StarLemmas.v
@@ -151,13 +151,16 @@ Qed.
 
 Lemma star_smallstep_binary_primitive:
   forall t1 v1 t2 v2 o,
-    cbv_value v1 ->
-    cbv_value v2 ->
     t1 ~>* v1 ->
     t2 ~>* v2 ->
+    cbv_value v1 ->
+    cbv_value v2 ->
     binary_primitive o t1 t2 ~>* binary_primitive o v1 v2.
 Proof.
-  steps; eauto using star_trans with cbvlemmas.
+  steps;
+    eauto using star_trans,
+    star_smallstep_binary_primitive_l,
+    star_smallstep_binary_primitive_r with cbvlemmas.
 Qed.
 
 Hint Resolve star_smallstep_binary_primitive: cbvlemmas.

--- a/StarLemmas.v
+++ b/StarLemmas.v
@@ -122,45 +122,48 @@ Qed.
 
 Lemma star_smallstep_unary_primitive:
   forall t1 t2,
-    star scbv_step t1 t2 ->
+    t1 ~>* t2 ->
     forall o,
-      star scbv_step (unary_primitive o t1) (unary_primitive o t2).
+      unary_primitive o t1 ~>* unary_primitive o t2.
 Proof.
   induction 1; steps; eauto with smallstep star.
 Qed.
 
 Lemma star_smallstep_binary_primitive_l:
   forall t1 t2,
-    star scbv_step t1 t2 ->
+    t1 ~>* t2 ->
     forall o t,
-      star scbv_step (binary_primitive o t1 t) (binary_primitive o t2 t).
+      binary_primitive o t1 t ~>* binary_primitive o t2 t.
 Proof.
   induction 1; steps; eauto with smallstep star.
 Qed.
 
 Lemma star_smallstep_binary_primitive_r:
   forall t1 t2,
-    star scbv_step t1 t2 ->
+    t1 ~>* t2 ->
     forall o v,
       cbv_value v ->
-      star scbv_step (binary_primitive o v t1) (binary_primitive o v t2).
+      binary_primitive o v t1 ~>* binary_primitive o v t2.
 Proof.
   induction 1; steps; eauto with smallstep star.
 Qed.
 
-Hint Resolve star_smallstep_unary_primitive: cbvlemmas.
-Hint Resolve star_smallstep_binary_primitive_l: cbvlemmas.
-Hint Resolve star_smallstep_binary_primitive_r: cbvlemmas.
 
 Lemma star_smallstep_binary_primitive:
-  forall t1 v t2 t2' o,
-    cbv_value v ->
-    star scbv_step t1 v ->
-    star scbv_step t2 t2' ->
-    star scbv_step (binary_primitive o t1 t2) (binary_primitive o v t2').
+  forall t1 v1 t2 v2 o,
+    cbv_value v1 ->
+    cbv_value v2 ->
+    t1 ~>* v1 ->
+    t2 ~>* v2 ->
+    binary_primitive o t1 t2 ~>* binary_primitive o v1 v2.
 Proof.
   steps; eauto using star_trans with cbvlemmas.
 Qed.
+
+Hint Resolve star_smallstep_binary_primitive: cbvlemmas.
+Hint Resolve star_smallstep_unary_primitive: cbvlemmas.
+Hint Resolve star_smallstep_binary_primitive_l: cbvlemmas.
+Hint Resolve star_smallstep_binary_primitive_r: cbvlemmas.
 
 Lemma star_smallstep_err:
   forall t v,

--- a/StarLemmas.v
+++ b/StarLemmas.v
@@ -120,6 +120,48 @@ Proof.
   induction 1; steps; eauto with smallstep star.
 Qed.
 
+Lemma star_smallstep_unary_primitive:
+  forall t1 t2,
+    star scbv_step t1 t2 ->
+    forall o,
+      star scbv_step (unary_primitive o t1) (unary_primitive o t2).
+Proof.
+  induction 1; steps; eauto with smallstep star.
+Qed.
+
+Lemma star_smallstep_binary_primitive_l:
+  forall t1 t2,
+    star scbv_step t1 t2 ->
+    forall o t,
+      star scbv_step (binary_primitive o t1 t) (binary_primitive o t2 t).
+Proof.
+  induction 1; steps; eauto with smallstep star.
+Qed.
+
+Lemma star_smallstep_binary_primitive_r:
+  forall t1 t2,
+    star scbv_step t1 t2 ->
+    forall o v,
+      cbv_value v ->
+      star scbv_step (binary_primitive o v t1) (binary_primitive o v t2).
+Proof.
+  induction 1; steps; eauto with smallstep star.
+Qed.
+
+Hint Resolve star_smallstep_unary_primitive: cbvlemmas.
+Hint Resolve star_smallstep_binary_primitive_l: cbvlemmas.
+Hint Resolve star_smallstep_binary_primitive_r: cbvlemmas.
+
+Lemma star_smallstep_binary_primitive:
+  forall t1 v t2 t2' o,
+    cbv_value v ->
+    star scbv_step t1 v ->
+    star scbv_step t2 t2' ->
+    star scbv_step (binary_primitive o t1 t2) (binary_primitive o v t2').
+Proof.
+  steps; eauto using star_trans with cbvlemmas.
+Qed.
+
 Lemma star_smallstep_err:
   forall t v,
     t ~>* v ->

--- a/SwapTermHoles.v
+++ b/SwapTermHoles.v
@@ -54,6 +54,9 @@ Fixpoint swap_term_holes t i j :=
           (swap_term_holes t1 i j)
           (swap_term_holes t2 (S i) (S j))
 
+  | unary_primitive o t => unary_primitive o (swap_term_holes t i j)
+  | binary_primitive o t1 t2 => binary_primitive o (swap_term_holes t1 i j) (swap_term_holes t2 i j)
+
   | tfix T t' => tfix (swap_term_holes T (S i) (S j)) (swap_term_holes t' (S (S i))  (S (S j)))
   | notype_tfix t' => notype_tfix (swap_term_holes t' (S (S i)) (S (S j)))
 

--- a/SwapTypeHoles.v
+++ b/SwapTypeHoles.v
@@ -53,6 +53,9 @@ Fixpoint swap_type_holes t i j :=
           (swap_type_holes t1 i j)
           (swap_type_holes t2 i j)
 
+  | unary_primitive o t => unary_primitive o (swap_type_holes t i j)
+  | binary_primitive o t1 t2 => binary_primitive o (swap_type_holes t1 i j) (swap_type_holes t2 i j)
+
   | tfix T t' => tfix (swap_type_holes T i j) (swap_type_holes t' i j)
   | notype_tfix t' => notype_tfix (swap_type_holes t' i j)
 

--- a/TermLift.v
+++ b/TermLift.v
@@ -80,6 +80,17 @@ Inductive term_lift (rel: tree -> tree -> Prop): tree -> tree -> Prop :=
       term_lift rel t t' ->
       term_lift rel (pi2 t) (pi2 t')
 
+| LiUnaryPrimitive:
+    forall o t t',
+      term_lift rel t t' ->
+      term_lift rel (unary_primitive o t) (unary_primitive o t')
+
+| LiBinaryPrimitive:
+    forall o t1 t2 t1' t2',
+      term_lift rel t1 t1' ->
+      term_lift rel t2 t2' ->
+      term_lift rel (binary_primitive o t1 t2) (binary_primitive o t1' t2')
+
 | LiBecause:
     forall t1 t1' t2 t2',
       term_lift rel t1 t1' ->

--- a/Trees.v
+++ b/Trees.v
@@ -2,6 +2,8 @@ Require Export SystemFR.Tactics.
 
 Inductive fv_tag: Set := term_var | type_var.
 
+Inductive op: Set := plus | minus | mul | div | eq | neq | lt | leq | gt | geq | Not | And | Or | Cup | Nop .
+
 Ltac destruct_tag :=
   match goal with
   | tag: fv_tag |- _ => destruct tag
@@ -62,6 +64,9 @@ Inductive tree: Set :=
   | succ: tree -> tree
   | tmatch: tree -> tree -> tree -> tree
 
+  | unary_primitive : op -> tree -> tree
+  | binary_primitive : op -> tree -> tree -> tree
+
   | tfix: tree -> tree -> tree
   | notype_tfix: tree -> tree
 
@@ -121,6 +126,9 @@ Fixpoint is_annotated_term t :=
   | zero => True
   | succ t' => is_annotated_term t'
   | tmatch t' t0 ts => is_annotated_term t' /\ is_annotated_term t0 /\ is_annotated_term ts
+
+  | unary_primitive _ t => is_annotated_term t
+  | binary_primitive _ t1 t2 => is_annotated_term t1 /\ is_annotated_term t2
 
   | tfix T t' => is_annotated_type T /\ is_annotated_term t'
 
@@ -261,6 +269,9 @@ Fixpoint tree_size t :=
   | succ t' =>  1 + tree_size t'
   | tmatch t' t0 ts => 1 + tree_size t' + tree_size t0 + tree_size ts
 
+  | unary_primitive _ t => 1 + tree_size t
+  | binary_primitive _ t1 t2 => 1 + tree_size t1 + tree_size t2
+
   | tfix T t' => 1 + tree_size T + tree_size t'
   | notype_tfix t' => 1 + tree_size t'
 
@@ -314,3 +325,8 @@ Lemma build_nat_inj:
 Proof.
   induction n1; destruct n2; steps.
 Qed.
+
+Ltac build_nat_inj :=
+  match goal with
+  |H: build_nat ?n1 = build_nat ?n2 |- _ => apply build_nat_inj in H
+  end.

--- a/Trees.v
+++ b/Trees.v
@@ -2,7 +2,7 @@ Require Export SystemFR.Tactics.
 
 Inductive fv_tag: Set := term_var | type_var.
 
-Inductive op: Set := plus | minus | mul | div | eq | neq | lt | leq | gt | geq | Not | And | Or | Cup | Nop .
+Inductive op: Set := Plus | Minus | Mul | Div | Eq | Neq | Lt | Leq | Gt | Geq | Not | And | Or | Cup | Nop .
 
 Ltac destruct_tag :=
   match goal with
@@ -200,6 +200,9 @@ Fixpoint is_erased_term t :=
   | zero => True
   | succ t' => is_erased_term t'
   | tmatch t' t0 ts => is_erased_term t' /\ is_erased_term t0 /\ is_erased_term ts
+
+  | unary_primitive _ t => is_erased_term t
+  | binary_primitive _ t1 t2 => is_erased_term t1 /\ is_erased_term t2
 
   | notype_tfix t' => is_erased_term t'
 

--- a/Trees.v
+++ b/Trees.v
@@ -329,7 +329,18 @@ Proof.
   induction n1; destruct n2; steps.
 Qed.
 
+Lemma build_nat_zero:
+  forall n,
+    build_nat n = zero ->
+    n = 0.
+Proof.
+  destruct n; steps.
+Qed.
+
+
 Ltac build_nat_inj :=
   match goal with
   |H: build_nat ?n1 = build_nat ?n2 |- _ => apply build_nat_inj in H
+  |H: zero = build_nat ?n |-_ => apply eq_sym, build_nat_zero in H
+  |H: build_nat ?n = zero |-_ => apply build_nat_zero in H
   end.

--- a/TypeErasure.v
+++ b/TypeErasure.v
@@ -37,6 +37,9 @@ Fixpoint erase_term (t: tree): tree :=
   | succ t' => succ (erase_term t')
   | tmatch t' t0 ts => tmatch (erase_term t') (erase_term t0) (erase_term ts)
 
+  | unary_primitive o t => unary_primitive o (erase_term t)
+  | binary_primitive o t1 t2 => binary_primitive o (erase_term t1) (erase_term t2)
+
   | notype_tlet t1 t2 => app (notype_lambda (erase_term t2)) (erase_term t1)
   | tlet t1 A t2 => app (notype_lambda (erase_term t2)) (erase_term t1)
   | trefl t1 t2 => uu

--- a/WFLemmas.v
+++ b/WFLemmas.v
@@ -133,3 +133,11 @@ Qed.
 
 Hint Resolve wf_subst: wf.
 
+Lemma wf_build_nat:
+  forall n k,
+    wf (build_nat n) k.
+Proof.
+  induction n; steps.
+Qed.
+
+Hint Resolve wf_build_nat: wf.


### PR DESCRIPTION
This PR adds a set of primitives into the language to represent basic operations (+,×,-,÷,≥,>,≤,<,=,≠,~). Typing rules are added for those primitives. The use of `tlt` is replaced by `binary_primitive Lt` in the Fix and Rec rules. The Evaluator is also updated.