### PR TITLE
Update to Rocq 9.0.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,28 @@
+name: Build
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Setup Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Build Docker image
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        tags: systemfr
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        load: true
+
+    - name: Build SystemFR
+      run: docker run --rm -v "$(pwd)":/theories systemfr

--- a/AnnotatedEquivalentInContext.v
+++ b/AnnotatedEquivalentInContext.v
@@ -1,4 +1,4 @@
-Require Import Coq.Lists.List.
+From Stdlib Require Import List.
 
 Require Export SystemFR.AnnotatedTactics.
 Require Export SystemFR.Judgments.

--- a/AnnotatedEquivalentMisc.v
+++ b/AnnotatedEquivalentMisc.v
@@ -1,4 +1,4 @@
-Require Import Coq.Lists.List.
+From Stdlib Require Import List.
 
 Require Export SystemFR.AnnotatedTactics.
 Require Export SystemFR.Judgments.

--- a/AnnotatedEquivalentSplit.v
+++ b/AnnotatedEquivalentSplit.v
@@ -1,4 +1,4 @@
-Require Import Coq.Lists.List.
+From Stdlib Require Import List.
 
 Require Export SystemFR.AnnotatedTactics.
 Require Export SystemFR.Judgments.

--- a/AnnotatedFix.v
+++ b/AnnotatedFix.v
@@ -1,4 +1,4 @@
-Require Import Coq.Lists.List.
+From Stdlib Require Import List.
 
 Require Export SystemFR.Judgments.
 Require Export SystemFR.AnnotatedTactics.

--- a/AnnotatedNat.v
+++ b/AnnotatedNat.v
@@ -1,4 +1,4 @@
-Require Import Coq.Lists.List.
+From Stdlib Require Import List.
 
 Require Export SystemFR.Judgments.
 Require Export SystemFR.AnnotatedTactics.

--- a/AnnotatedPrimitiveSize.v
+++ b/AnnotatedPrimitiveSize.v
@@ -1,4 +1,4 @@
-Require Import Coq.Lists.List.
+From Stdlib Require Import List.
 
 Require Export SystemFR.Judgments.
 Require Export SystemFR.AnnotatedTactics.

--- a/AnnotatedRec.v
+++ b/AnnotatedRec.v
@@ -1,4 +1,4 @@
-Require Import Coq.Lists.List.
+From Stdlib Require Import List.
 
 Require Export SystemFR.ErasedRec.
 Require Export SystemFR.AnnotatedTactics.

--- a/AnnotatedRecognizers.v
+++ b/AnnotatedRecognizers.v
@@ -1,4 +1,4 @@
-Require Import Coq.Lists.List.
+From Stdlib Require Import List.
 
 Require Export SystemFR.Judgments.
 Require Export SystemFR.AnnotatedTactics.

--- a/AnnotatedTermLemmas.v
+++ b/AnnotatedTermLemmas.v
@@ -1,4 +1,4 @@
-Require Import Coq.Strings.String.
+From Stdlib Require Import String.
 
 Require Export SystemFR.TypeErasure.
 Require Export SystemFR.TypeErasureLemmas.

--- a/AnnotatedVar.v
+++ b/AnnotatedVar.v
@@ -1,4 +1,4 @@
-Require Import PeanoNat.
+From Stdlib Require Import PeanoNat.
 
 Require Export SystemFR.Judgments.
 Require Export SystemFR.TypeErasureLemmas.

--- a/AssocList.v
+++ b/AssocList.v
@@ -1,9 +1,9 @@
-Require Import Coq.Strings.String.
-Require Import Coq.Lists.List.
+From Stdlib Require Import String.
+From Stdlib Require Import List.
 
 Require Export SystemFR.ListSetLemmas.
 
-Require Import PeanoNat.
+From Stdlib Require Import PeanoNat.
 
 Close Scope string_scope.
 
@@ -507,7 +507,7 @@ Proof.
 Qed.
 
 Ltac list_utils2 :=
-  rewrite map_length in * || rewrite support_nil in * || rewrite in_map_iff in * ||
+  rewrite length_map in * || rewrite support_nil in * || rewrite in_map_iff in * ||
   rewrite range_append in * || rewrite range_combine in * ||
   rewrite List.map_map in * || rewrite support_combine in * ||
   rewrite length_support in * || rewrite length_range in * ||

--- a/BaseType.v
+++ b/BaseType.v
@@ -1,5 +1,5 @@
-Require Import Coq.Lists.List.
-Require Import Coq.Strings.String.
+From Stdlib Require Import List.
+From Stdlib Require Import String.
 
 Require Export SystemFR.Trees.
 Require Export SystemFR.Syntax.

--- a/BaseTypeErase.v
+++ b/BaseTypeErase.v
@@ -1,5 +1,5 @@
-Require Import Coq.Lists.List.
-Require Import Coq.Strings.String.
+From Stdlib Require Import List.
+From Stdlib Require Import String.
 
 Require Export SystemFR.Trees.
 Require Export SystemFR.Syntax.

--- a/BaseTypeLemmas.v
+++ b/BaseTypeLemmas.v
@@ -1,10 +1,10 @@
-Require Import Coq.Lists.List.
-Require Import Coq.Strings.String.
+From Stdlib Require Import List.
+From Stdlib Require Import String.
 
 Require Export SystemFR.ReducibilityUnused.
 Require Export SystemFR.BaseType.
 
-Require Import Psatz.
+From Stdlib Require Import Psatz.
 
 Opaque reducible_values.
 

--- a/BigStep.v
+++ b/BigStep.v
@@ -9,7 +9,7 @@ Require Import SystemFR.WFLemmas.
 Require Import SystemFR.Evaluator.
 Require Import SystemFR.StarLemmas.
 
-Require Import String.
+From Stdlib Require Import String.
 
 Reserved Notation "t '~~>*' v" (at level 20).
 

--- a/CPS.v
+++ b/CPS.v
@@ -12,16 +12,16 @@ Require Import SystemFR.CloseLemmas.
 Require Import SystemFR.WFLemmasClose.
 Require Import SystemFR.WFLemmas.
 
-Require Import Coq.Strings.String.
-Require Import Coq.Arith.Compare_dec.
+From Stdlib Require Import String.
+From Stdlib Require Import Compare_dec.
 
-Require Import Program.
+From Stdlib Require Import Program.
 From Equations Require Import Equations.
 (* Require Import Equations.Prop.Subterm. *)
 
-Require Import PeanoNat.
-Require Import Relations.Relation_Operators.
-Require Import Lia.
+From Stdlib Require Import PeanoNat.
+From Stdlib Require Import Relations.Relation_Operators.
+From Stdlib Require Import Lia.
 
 Lemma open_t_size: forall t i nf, tree_size (open i t (fvar nf term_var)) = tree_size t.
 Proof.
@@ -203,7 +203,7 @@ Definition cps_value (t : tree) := cps_rec true t 0.
 
 Opaque cps_rec.
 
-Require Import Coq.Classes.RelationClasses.
+From Stdlib Require Import RelationClasses.
 
 (* see https://github.com/coq/coq/issues/3814 *)
 #[export] Instance: subrelation eq Basics.impl.

--- a/ComputableEquality.v
+++ b/ComputableEquality.v
@@ -1,4 +1,4 @@
-Require Import List.
+From Stdlib Require Import List.
 Import ListNotations.
 
 Require Export SystemFR.ErasedArrow.

--- a/ComputableEqualityTypedEquality.v
+++ b/ComputableEqualityTypedEquality.v
@@ -1,4 +1,4 @@
-Require Import List.
+From Stdlib Require Import List.
 Import ListNotations.
 
 Require Export SystemFR.ComputableEquality.

--- a/DeltaBetaReduction.v
+++ b/DeltaBetaReduction.v
@@ -1,6 +1,6 @@
-Require Import Coq.Strings.String.
+From Stdlib Require Import String.
 From Equations Require Import Equations.
-Require Import PeanoNat.
+From Stdlib Require Import PeanoNat.
 
 Require Export SystemFR.EquivalentContext.
 Require Export SystemFR.ErasedList.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM rocq/rocq-prover:9.0
+RUN opam update && opam install -y rocq-equations.1.3.1+9.0
+WORKDIR /theories-local
+VOLUME /theories-local
+CMD ["bash", "-l", "-c", "cp -r /theories/*.v /theories/configure /theories-local && ./configure && TIMED= TIMECMD= make -j8"]

--- a/EqualWithRelation.v
+++ b/EqualWithRelation.v
@@ -1,5 +1,5 @@
-Require Import Coq.Strings.String.
-Require Import PeanoNat.
+From Stdlib Require Import String.
+From Stdlib Require Import PeanoNat.
 
 Require Export SystemFR.SizeLemmas.
 Require Export SystemFR.StarLemmas.

--- a/Equivalence.v
+++ b/Equivalence.v
@@ -1,4 +1,4 @@
-Require Import Coq.Strings.String.
+From Stdlib Require Import String.
 
 Require Export SystemFR.StarLemmas.
 Require Export SystemFR.ErasedTermLemmas.

--- a/EquivalentPairsWithRelation.v
+++ b/EquivalentPairsWithRelation.v
@@ -1,4 +1,4 @@
-Require Import Coq.Strings.String.
+From Stdlib Require Import String.
 
 Require Export SystemFR.AssocList.
 Require Export SystemFR.Tactics.
@@ -7,7 +7,7 @@ Require Export SystemFR.Trees.
 Require Export SystemFR.Syntax.
 Require Export SystemFR.ListUtils.
 
-Require Import PeanoNat.
+From Stdlib Require Import PeanoNat.
 
 Open Scope list_scope.
 

--- a/EquivalentStar.v
+++ b/EquivalentStar.v
@@ -6,9 +6,9 @@ Require Export SystemFR.EqualWithRelation.
 Require Export SystemFR.TermLift.
 Require Export SystemFR.EquivalenceLemmas.
 
-Require Import Coq.Strings.String.
-Require Import Psatz.
-Require Import PeanoNat.
+From Stdlib Require Import String.
+From Stdlib Require Import Psatz.
+From Stdlib Require Import PeanoNat.
 
 Opaque loop.
 Opaque makeFresh.

--- a/EquivalentWithRelation.v
+++ b/EquivalentWithRelation.v
@@ -1,11 +1,11 @@
-Require Import Coq.Strings.String.
+From Stdlib Require Import String.
 
 Require Export SystemFR.AssocList.
 Require Export SystemFR.Tactics.
 
 Require Export SystemFR.ReducibilityCandidate.
 
-Require Import PeanoNat.
+From Stdlib Require Import PeanoNat.
 
 Open Scope list_scope.
 

--- a/ErasedArrow.v
+++ b/ErasedArrow.v
@@ -1,5 +1,5 @@
 From Equations Require Import Equations.
-Require Import Coq.Lists.List.
+From Stdlib Require Import List.
 
 Require Export SystemFR.ReducibilityOpenEquivalent.
 

--- a/ErasedBool.v
+++ b/ErasedBool.v
@@ -1,5 +1,5 @@
 From Equations Require Import Equations.
-Require Import Coq.Lists.List.
+From Stdlib Require Import List.
 
 Require Export SystemFR.RedTactics.
 

--- a/ErasedEquivalent.v
+++ b/ErasedEquivalent.v
@@ -1,4 +1,4 @@
-Require Import Coq.Strings.String.
+From Stdlib Require Import String.
 
 Require Export SystemFR.RedTactics.
 

--- a/ErasedEquivalentPrimitive.v
+++ b/ErasedEquivalentPrimitive.v
@@ -1,5 +1,5 @@
 Require Export SystemFR.ErasedPrimitive.
-Require Import Coq.Strings.String.
+From Stdlib Require Import String.
 
 
 Lemma reducible_values_primitive_EqEquiv1:
@@ -15,7 +15,7 @@ Proof.
   unfold equivalent_terms; steps; eauto with erased values wf fv.
 Qed.
 
-Opaque Coq.Init.Wf.Fix_F.
+Opaque Corelib.Init.Wf.Fix_F.
 Opaque  Subterm.FixWf.
 
 Lemma reducible_primitive_EqEquiv1:

--- a/ErasedEquivalentSplitMatch.v
+++ b/ErasedEquivalentSplitMatch.v
@@ -1,4 +1,4 @@
-Require Import Coq.Lists.List.
+From Stdlib Require Import List.
 
 Require Export SystemFR.RedTactics.
 Require Export SystemFR.ErasedEquivalentMatch.

--- a/ErasedFix.v
+++ b/ErasedFix.v
@@ -1,6 +1,6 @@
 From Equations Require Import Equations.
-Require Import Coq.Lists.List.
-Require Import Coq.Arith.PeanoNat.
+From Stdlib Require Import List.
+From Stdlib Require Import PeanoNat.
 
 Require Export SystemFR.ReducibilityEquivalent.
 Require Export SystemFR.ErasedArrow.
@@ -9,7 +9,7 @@ Require Export SystemFR.ErasedQuant.
 Require Export SystemFR.ErasedNat.
 Require Export SystemFR.ErasedPrimitive.
 
-Require Import Psatz.
+From Stdlib Require Import Psatz.
 
 Opaque reducible_values.
 Opaque makeFresh.

--- a/ErasedIte.v
+++ b/ErasedIte.v
@@ -4,7 +4,7 @@ Require Export SystemFR.ErasedSetOps.
 
 Require Export SystemFR.TypeSugar.
 
-Require Import Coq.Lists.List.
+From Stdlib Require Import List.
 
 Opaque reducible_values.
 

--- a/ErasedLet.v
+++ b/ErasedLet.v
@@ -1,6 +1,6 @@
 From Equations Require Import Equations.
 
-Require Import Coq.Lists.List.
+From Stdlib Require Import List.
 
 Require Export SystemFR.RedTactics.
 Require Export SystemFR.ReducibilityOpenEquivalent.

--- a/ErasedLet2.v
+++ b/ErasedLet2.v
@@ -1,6 +1,6 @@
 From Equations Require Import Equations.
 
-Require Import Coq.Lists.List.
+From Stdlib Require Import List.
 
 Require Export SystemFR.RedTactics.
 

--- a/ErasedList.v
+++ b/ErasedList.v
@@ -141,7 +141,7 @@ Lemma reducible_nil:
     [ ρ ⊨ tnil : List ]v.
 Proof.
   unshelve epose proof (open_reducible_nil nil nil); steps.
-  rewrite (List.app_nil_end ρ).
+  rewrite <- (List.app_nil_r ρ).
   apply reducible_unused_many2; repeat step || apply reducible_expr_value;
     eauto using no_type_fvar_List;
     eauto using cbv_value_nil.

--- a/ErasedNat.v
+++ b/ErasedNat.v
@@ -1,6 +1,6 @@
 From Equations Require Import Equations.
-Require Import Coq.Lists.List.
-Require Import Coq.Arith.PeanoNat.
+From Stdlib Require Import List.
+From Stdlib Require Import PeanoNat.
 
 Require Export SystemFR.ErasedArrow.
 

--- a/ErasedPair.v
+++ b/ErasedPair.v
@@ -1,7 +1,7 @@
 From Equations Require Import Equations.
 
-Require Import Coq.Arith.PeanoNat.
-Require Import Coq.Lists.List.
+From Stdlib Require Import PeanoNat.
+From Stdlib Require Import List.
 
 Require Export SystemFR.ReducibilityOpenEquivalent.
 

--- a/ErasedPolymorphism.v
+++ b/ErasedPolymorphism.v
@@ -1,4 +1,4 @@
-Require Import Coq.Lists.List.
+From Stdlib Require Import List.
 
 Require Export SystemFR.ReducibilitySubst.
 

--- a/ErasedRec.v
+++ b/ErasedRec.v
@@ -1,7 +1,7 @@
 From Equations Require Import Equations.
 
-Require Import Coq.Strings.String.
-Require Import Coq.Lists.List.
+From Stdlib Require Import String.
+From Stdlib Require Import List.
 
 Require Export SystemFR.ReducibilitySubst.
 Require Export SystemFR.SomeTerms.

--- a/ErasedRecGen.v
+++ b/ErasedRecGen.v
@@ -1,5 +1,5 @@
-Require Import Coq.Strings.String.
-Require Import Coq.Lists.List.
+From Stdlib Require Import String.
+From Stdlib Require Import List.
 From Equations Require Import Equations.
 
 Require Export SystemFR.ErasedRec.
@@ -15,7 +15,7 @@ Require Export SystemFR.StrictPositivitySubst.
 Require Export SystemFR.BaseTypeLemmas.
 Require Export SystemFR.BaseTypeSyntaxLemmas.
 
-Require Import Psatz.
+From Stdlib Require Import Psatz.
 
 Opaque reducible_values.
 Opaque strictly_positive.

--- a/ErasedRecPos.v
+++ b/ErasedRecPos.v
@@ -1,8 +1,8 @@
-Require Import Psatz.
+From Stdlib Require Import Psatz.
 From Equations Require Import Equations.
 
-Require Import Coq.Strings.String.
-Require Import Coq.Lists.List.
+From Stdlib Require Import String.
+From Stdlib Require Import List.
 
 Require Export SystemFR.ErasedRec.
 Require Export SystemFR.PolarityLemma.

--- a/ErasedRefine.v
+++ b/ErasedRefine.v
@@ -1,7 +1,7 @@
 From Equations Require Import Equations.
 
-Require Import Coq.Arith.PeanoNat.
-Require Import Coq.Lists.List.
+From Stdlib Require Import PeanoNat.
+From Stdlib Require Import List.
 
 Require Export SystemFR.ErasedLet2.
 

--- a/ErasedSetOps.v
+++ b/ErasedSetOps.v
@@ -1,7 +1,7 @@
 From Equations Require Import Equations.
 
-Require Import Coq.Arith.PeanoNat.
-Require Import Coq.Lists.List.
+From Stdlib Require Import PeanoNat.
+From Stdlib Require Import List.
 
 Require Export SystemFR.ErasedLet.
 Require Export SystemFR.RedTactics.

--- a/ErasedSubtype.v
+++ b/ErasedSubtype.v
@@ -1,8 +1,8 @@
 From Equations Require Import Equations.
 
-Require Import Coq.Strings.String.
-Require Import Coq.Arith.PeanoNat.
-Require Import Coq.Lists.List.
+From Stdlib Require Import String.
+From Stdlib Require Import PeanoNat.
+From Stdlib Require Import List.
 
 Require Export SystemFR.ReducibilityOpenEquivalent.
 

--- a/ErasedSum.v
+++ b/ErasedSum.v
@@ -1,7 +1,7 @@
 From Equations Require Import Equations.
 
-Require Import Coq.Arith.PeanoNat.
-Require Import Coq.Lists.List.
+From Stdlib Require Import PeanoNat.
+From Stdlib Require Import List.
 
 Require Export SystemFR.ErasedLet2.
 Require Export SystemFR.ReducibilityOpenEquivalent.

--- a/ErasedTypeApplication.v
+++ b/ErasedTypeApplication.v
@@ -1,5 +1,5 @@
 From Equations Require Import Equations.
-Require Import Coq.Lists.List.
+From Stdlib Require Import List.
 
 Require Export SystemFR.ReducibilityOpenEquivalent.
 Require Export SystemFR.ErasedTypeRefine.

--- a/ErasedTypeReduction.v
+++ b/ErasedTypeReduction.v
@@ -1,5 +1,5 @@
 From Equations Require Import Equations.
-Require Import Coq.Lists.List.
+From Stdlib Require Import List.
 Import ListNotations.
 
 Require Export SystemFR.ErasedTypeRefine.

--- a/ErasedTypeRefine.v
+++ b/ErasedTypeRefine.v
@@ -1,8 +1,8 @@
 From Equations Require Import Equations.
 
-Require Import Coq.Arith.PeanoNat.
-Require Import Coq.Lists.List.
-Require Import Coq.Strings.String.
+From Stdlib Require Import PeanoNat.
+From Stdlib Require Import List.
+From Stdlib Require Import String.
 
 Require Export SystemFR.ErasedLet.
 Require Export SystemFR.ReducibilityOpenEquivalent.

--- a/ErasedVar.v
+++ b/ErasedVar.v
@@ -1,7 +1,7 @@
 From Equations Require Import Equations.
 
-Require Import Coq.Arith.PeanoNat.
-Require Import Coq.Lists.List.
+From Stdlib Require Import PeanoNat.
+From Stdlib Require Import List.
 
 Require Export SystemFR.RedTactics.
 

--- a/EvalFixDefault.v
+++ b/EvalFixDefault.v
@@ -1,4 +1,4 @@
-Require Import Coq.Strings.String.
+From Stdlib Require Import String.
 
 Require Export SystemFR.EquivalentContext.
 Require Export SystemFR.ScalaDepSugar.

--- a/EvalListMatch.v
+++ b/EvalListMatch.v
@@ -1,4 +1,4 @@
-Require Import Coq.Strings.String.
+From Stdlib Require Import String.
 
 Require Export SystemFR.ScalaDepSugar.
 Require Export SystemFR.ErasedRecGen.

--- a/Evaluator.v
+++ b/Evaluator.v
@@ -4,7 +4,7 @@ Require Export SystemFR.Notations.
 
 Require Export SystemFR.SmallStep.
 
-Require Import Coq.Strings.String.
+From Stdlib Require Import String.
 Open Scope bool_scope.
 
 (* Helpers *)

--- a/Existss.v
+++ b/Existss.v
@@ -1,4 +1,4 @@
-Require Import Coq.Lists.List.
+From Stdlib Require Import List.
 
 Require Export SystemFR.ReducibilityLemmas.
 Require Export SystemFR.CloseLemmas.
@@ -93,7 +93,7 @@ Proof.
   unfold T_exists_vars in *.
   simp_red_goal; steps; eauto 4 with erased; eauto using reducible_values_closed.
   exists t; repeat step || rewrite open_existss; eauto with erased fv wf.
-  rewrite <- rev_length at 2.
+  rewrite <- length_rev at 2.
   rewrite open_closes; steps; eauto with wf fv.
 Qed.
 
@@ -114,9 +114,9 @@ Proof.
     eauto 2 with step_tactic.
 
   rewrite open_existss in *; eauto with wf.
-  rewrite <- rev_length in * at 2.
+  rewrite <- length_rev in * at 2.
   rewrite open_closes in *; eauto with wf fv.
-  rewrite rev_length in *.
+  rewrite length_rev in *.
 
   unshelve epose proof (IHxs _ _ _ _ _ _ _ _ _ H9); steps;
     eauto 2 with wf step_tactic;

--- a/FVLemmas.v
+++ b/FVLemmas.v
@@ -1,7 +1,7 @@
-Require Import Coq.Strings.String.
-Require Import Coq.Lists.List.
-Require Import Coq.Init.Datatypes.
-Require Import Coq.Arith.PeanoNat.
+From Stdlib Require Import String.
+From Stdlib Require Import List.
+From Stdlib Require Import Datatypes.
+From Stdlib Require Import PeanoNat.
 
 Require Export SystemFR.Syntax.
 

--- a/FVLemmasClose.v
+++ b/FVLemmasClose.v
@@ -1,7 +1,7 @@
-Require Import Coq.Strings.String.
-Require Import Coq.Lists.List.
-Require Import Coq.Init.Datatypes.
-Require Import Coq.Arith.PeanoNat.
+From Stdlib Require Import String.
+From Stdlib Require Import List.
+From Stdlib Require Import Datatypes.
+From Stdlib Require Import PeanoNat.
 
 Require Export SystemFR.FVLemmas.
 

--- a/FVLemmasEval.v
+++ b/FVLemmasEval.v
@@ -1,4 +1,4 @@
-Require Import Coq.Strings.String.
+From Stdlib Require Import String.
 From Equations Require Import Equations.
 
 Require Export SystemFR.FVLemmas.

--- a/FVLemmasLists.v
+++ b/FVLemmasLists.v
@@ -1,5 +1,5 @@
-Require Import Coq.Strings.String.
-Require Import Coq.Lists.List.
+From Stdlib Require Import String.
+From Stdlib Require Import List.
 
 Require Export SystemFR.FVLemmas.
 Require Export SystemFR.TypeErasureLemmas.
@@ -145,7 +145,7 @@ Lemma subst_subst:
     psubstitute t (combine xs (List.map (fun t' => psubstitute t' l tag) ts)) tag.
 Proof.
   induction t; repeat step || t_equality;
-    eauto 4 using lookup_combine_some_none, List.map_length with exfalso;
+    eauto 4 using lookup_combine_some_none, length_map with exfalso;
     try solve [ rewrite_any; steps; eapply_any; eauto; repeat step || list_utils ];
     try solve [ eapply_anywhere lookup_combine_map; eauto ];
     try solve [ t_lookup; eauto with exfalso ].
@@ -161,7 +161,7 @@ Lemma subst_subst2:
                 (combine xs (List.map (fun t' => psubstitute t' l tag) ts)) tag.
 Proof.
   induction t; repeat step || t_equality;
-    eauto 4 using lookup_combine_some_none, List.map_length with exfalso;
+    eauto 4 using lookup_combine_some_none, length_map with exfalso;
     try solve [ eapply_anywhere lookup_combine_map; eauto ];
     try solve [ rewrite substitute_nothing5; eauto with fv ].
 

--- a/Freshness.v
+++ b/Freshness.v
@@ -1,5 +1,5 @@
-Require Import Coq.Lists.List.
-Require Import Psatz.
+From Stdlib Require Import List.
+From Stdlib Require Import Psatz.
 
 Require Export SystemFR.Tactics.
 Require Export SystemFR.ListUtils.

--- a/Functional.v
+++ b/Functional.v
@@ -1,6 +1,6 @@
-Require Import PeanoNat.
-Require Import Psatz.
-Require Import Coq.Lists.List.
+From Stdlib Require Import PeanoNat.
+From Stdlib Require Import Psatz.
+From Stdlib Require Import List.
 
 Require Export SystemFR.AssocList.
 Require Export SystemFR.SubstitutionLemmas.
@@ -62,7 +62,7 @@ Proof.
   - unfold functional, equivalent_subst; exists nil; steps.
   - unshelve epose proof (@exists_last _ l _);
       repeat step || destruct_refinement.
-    unshelve epose proof (IHn x _); repeat step || rewrite app_length in *; try lia.
+    unshelve epose proof (IHn x _); repeat step || rewrite length_app in *; try lia.
     exists (l' ++ (n0, get_or_else (lookup Nat.eq_dec l' n0) t) :: nil);
       repeat step || apply equivalent_subst_snoc || list_utils || list_utils2;
       eauto 2 using functional_get_or_else.

--- a/IdRelation.v
+++ b/IdRelation.v
@@ -7,7 +7,7 @@ Require Export SystemFR.ListUtils.
 Require Export SystemFR.EqualWithRelation.
 Require Export SystemFR.EquivalentWithRelation.
 
-Require Import PeanoNat.
+From Stdlib Require Import PeanoNat.
 
 Open Scope list_scope.
 

--- a/InferFix.v
+++ b/InferFix.v
@@ -1,4 +1,4 @@
-Require Import Coq.Strings.String.
+From Stdlib Require Import String.
 
 Require Export SystemFR.ReducibilityEquivalent.
 Require Export SystemFR.ErasedSingleton.

--- a/InferMatch.v
+++ b/InferMatch.v
@@ -1,4 +1,4 @@
-Require Import Coq.Strings.String.
+From Stdlib Require Import String.
 
 Require Export SystemFR.ErasedSingleton.
 Require Export SystemFR.SubtypeList.

--- a/InferMisc.v
+++ b/InferMisc.v
@@ -1,4 +1,4 @@
-Require Import PeanoNat.
+From Stdlib Require Import PeanoNat.
 
 Require Export SystemFR.ErasedVar.
 Require Export SystemFR.ErasedArrow.

--- a/ListSetLemmas.v
+++ b/ListSetLemmas.v
@@ -1,5 +1,5 @@
-Require Import Coq.Strings.String.
-Require Import Coq.Lists.List.
+From Stdlib Require Import String.
+From Stdlib Require Import List.
 
 Require Export SystemFR.ListUtils.
 
@@ -249,7 +249,7 @@ Lemma subset_same:
     B = C ->
     subset A C.
 Proof.
-  intuition.
+  intros; subst; auto.
 Qed.
 
 Lemma subset_singleton:

--- a/ListUtils.v
+++ b/ListUtils.v
@@ -1,9 +1,9 @@
-Require Import Psatz.
+From Stdlib Require Import Psatz.
 
-Require Import Coq.Lists.List.
-Require Import Coq.Strings.String.
+From Stdlib Require Import List.
+From Stdlib Require Import String.
 
-Require Import Coq.Arith.PeanoNat.
+From Stdlib Require Import PeanoNat.
 
 Require Export SystemFR.Tactics.
 

--- a/LoopingTerm.v
+++ b/LoopingTerm.v
@@ -1,7 +1,7 @@
 Require Export SystemFR.StarInversions.
 Require Export SystemFR.WFLemmas.
 
-Require Import Psatz.
+From Stdlib Require Import Psatz.
 
 Definition loop: tree := notype_tfix (lvar 0 term_var).
 

--- a/Modulo.v
+++ b/Modulo.v
@@ -1,6 +1,6 @@
 Require Export SystemFR.Syntax.
 Require Export SystemFR.WFLemmas.
-Require Import Coq.Lists.List.
+From Stdlib Require Import List.
 Import ListNotations.
 Open Scope bool_scope.
 

--- a/NatEq.v
+++ b/NatEq.v
@@ -1,4 +1,4 @@
-Require Import Coq.Strings.String.
+From Stdlib Require Import String.
 
 Require Export SystemFR.EquivalentContext.
 Require Export SystemFR.StepTactics.

--- a/NatLessThan.v
+++ b/NatLessThan.v
@@ -1,4 +1,4 @@
-Require Import Coq.Strings.String.
+From Stdlib Require Import String.
 
 Require Export SystemFR.EquivalentContext.
 

--- a/NoTypeFVarLemmas.v
+++ b/NoTypeFVarLemmas.v
@@ -4,7 +4,7 @@ Require Export SystemFR.AssocList.
 Require Export SystemFR.NoTypeFVar.
 Require Export SystemFR.EqualWithRelation.
 
-Require Import PeanoNat.
+From Stdlib Require Import PeanoNat.
 
 Definition similar_sets (rel: map nat nat) (vars vars': list nat): Prop :=
   forall x y,

--- a/NormalizationMatch.v
+++ b/NormalizationMatch.v
@@ -1,4 +1,4 @@
-Require Import PeanoNat.
+From Stdlib Require Import PeanoNat.
 
 Require Export SystemFR.NormalizationSing.
 Require Export SystemFR.SubtypeList.

--- a/NormalizationMatch.v
+++ b/NormalizationMatch.v
@@ -130,7 +130,6 @@ Lemma reducibility_subst_equiv:
     [ ρ ⊨ v : psubstitute T ((x, t2) :: nil) term_var ]v.
 Proof.
   intros; repeat rewrite <- (open_close _ _ _ 0) in * by auto.
-  rewrite <- (open_close _ _ _ 0) in H by auto.
   eapply reducibility_open_equivalent; eauto; repeat step;
     eauto with erased wf;
     eauto using fv_close_nil2.

--- a/OpenTOpen.v
+++ b/OpenTOpen.v
@@ -1,5 +1,5 @@
-Require Import Coq.Strings.String.
-Require Import Psatz.
+From Stdlib Require Import String.
+From Stdlib Require Import Psatz.
 
 Require Export SystemFR.WFLemmas.
 Require Export SystemFR.TWFLemmas.

--- a/Polarity.v
+++ b/Polarity.v
@@ -1,6 +1,6 @@
 From Equations Require Import Equations.
 
-Require Import Psatz.
+From Stdlib Require Import Psatz.
 
 
 Require Export SystemFR.Syntax.

--- a/PolarityErase.v
+++ b/PolarityErase.v
@@ -1,9 +1,9 @@
 From Equations Require Import Equations.
 
-Require Import Psatz.
+From Stdlib Require Import Psatz.
 
-Require Import Coq.Strings.String.
-Require Import Coq.Lists.List.
+From Stdlib Require Import String.
+From Stdlib Require Import List.
 
 Require Export SystemFR.OpenTOpen.
 Require Export SystemFR.EqualWithRelation.

--- a/PolarityLemma.v
+++ b/PolarityLemma.v
@@ -1,10 +1,10 @@
 From Equations Require Import Equations.
 Require Import Equations.Prop.Subterm.
 
-Require Import Psatz.
+From Stdlib Require Import Psatz.
 
-Require Import Coq.Strings.String.
-Require Import Coq.Lists.List.
+From Stdlib Require Import String.
+From Stdlib Require Import List.
 
 Require Export SystemFR.PolarityLemmas.
 

--- a/PolarityLemmas.v
+++ b/PolarityLemmas.v
@@ -1,10 +1,10 @@
 From Equations Require Import Equations.
 Require Import Equations.Prop.Subterm.
 
-Require Import Psatz.
+From Stdlib Require Import Psatz.
 
-Require Import Coq.Strings.String.
-Require Import Coq.Lists.List.
+From Stdlib Require Import String.
+From Stdlib Require Import List.
 
 Require Export SystemFR.OpenTOpen.
 Require Export SystemFR.ReducibilitySubst.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ opam install rocq-equations.1.3.1+9.0 -y
 
 See [“Installing the Rocq Prover and its packages”](https://rocq-prover.org/docs/using-opam) for more details.
 
+### Docker
+
+Alternatively, you can also use the provided [Dockerfile](./Dockerfile) to build a Docker image with all dependencies installed:
+
+```
+docker build -t systemfr .
+docker run -v "$(pwd)":/theories systemfr
 ```
 
 ### Compiling the Proofs

--- a/README.md
+++ b/README.md
@@ -4,22 +4,29 @@
 
 ### Description
 
-This project aims to formalize in Coq part of the [Stainless project](https://github.com/epfl-lara/stainless). It describes a call-by-value lambda-calculus and defines a rich type system (based on computations) that describes behaviors of lambda-calculus terms. Supported types include: System F polymorphism, recursive types, infinite intersections, refinement and dependent types, equality types.
+This project aims to formalize in the Rocq Prover part of the [Stainless project](https://github.com/epfl-lara/stainless). It describes a call-by-value lambda-calculus and defines a rich type system (based on computations) that describes behaviors of lambda-calculus terms. Supported types include: System F polymorphism, recursive types, infinite intersections, refinement and dependent types, equality types.
 
 ### Requirements
 
-The proofs require Coq and Coq-Equations, which can be installed using `opam` with the `coq` and `coq-equations` packages. Some instructions are available [here](https://github.com/coq/coq/wiki/Installation-of-Coq-on-Linux) and [there](https://github.com/mattam82/Coq-Equations).
+The proofs require [Rocq](https://rocq-prover.org) and [Rocq-Equations](https://github.com/mattam82/Coq-Equations), which can be installed using `opam`:
 
-* Coq 8.14.0
-* Coq-Equations 1.3.0+8.14
+```
+opam repo add rocq-released https://rocq-prover.org/opam/released
+opam pin add -yn rocq-prover 9.0.0
+opam install rocq-equations.1.3.1+9.0 -y
+```
+
+See [“Installing the Rocq Prover and its packages”](https://rocq-prover.org/docs/using-opam) for more details.
+
+```
 
 ### Compiling the Proofs
 
-After installing Coq, you can compile the proofs using:
+After installing Rocq, you can compile the proofs using:
 
 ```
 ./configure
-make -j4     # should take around 25 minutes
+make -j8     # should take around 10 minutes
 ```
 
 ### Overview of the proofs

--- a/RedTactics.v
+++ b/RedTactics.v
@@ -1,4 +1,4 @@
-Require Import Coq.Strings.String.
+From Stdlib Require Import String.
 
 Require Export SystemFR.SubstitutionErase.
 Require Export SystemFR.EquivalentStar.

--- a/ReducibilityCandidate.v
+++ b/ReducibilityCandidate.v
@@ -1,4 +1,4 @@
-Require Import PeanoNat.
+From Stdlib Require Import PeanoNat.
 
 Require Export SystemFR.ErasedTermLemmas.
 Require Export SystemFR.EquivalenceLemmas.

--- a/ReducibilityDefinition.v
+++ b/ReducibilityDefinition.v
@@ -1,4 +1,4 @@
-Require Import Coq.Strings.String.
+From Stdlib Require Import String.
 
 Require Export SystemFR.TermList.
 Require Export SystemFR.ReducibilityMeasure.
@@ -6,9 +6,9 @@ Require Export SystemFR.ReducibilityCandidate.
 
 From Equations Require Import Equations.
 Require Import Equations.Prop.Subterm.
-Require Import Coq.Classes.RelationClasses.
+From Stdlib Require Import RelationClasses.
 
-Require Import Psatz.
+From Stdlib Require Import Psatz.
 
 Definition reduces_to (P: tree -> Prop) (t: tree) :=
   closed_term t /\

--- a/ReducibilityEquivalent.v
+++ b/ReducibilityEquivalent.v
@@ -1,6 +1,6 @@
 Require Import Equations.Prop.Subterm.
 
-Require Import Coq.Strings.String.
+From Stdlib Require Import String.
 
 Require Export SystemFR.ReducibilityOpenEquivalent.
 

--- a/ReducibilityLemmas.v
+++ b/ReducibilityLemmas.v
@@ -1,4 +1,4 @@
-Require Import Coq.Strings.String.
+From Stdlib Require Import String.
 
 From Equations Require Import Equations.
 
@@ -12,7 +12,7 @@ Require Export SystemFR.TWFLemmas.
 
 Require Export SystemFR.ReducibilityDefinition.
 
-Require Import Psatz.
+From Stdlib Require Import Psatz.
 
 Opaque reducible_values. (* workaround for rewriting speed *)
 

--- a/ReducibilityMeasure.v
+++ b/ReducibilityMeasure.v
@@ -1,4 +1,4 @@
-Require Import Psatz.
+From Stdlib Require Import Psatz.
 
 Require Export SystemFR.StarInversions.
 Require Export SystemFR.SizeLemmas.
@@ -7,7 +7,7 @@ Require Export SystemFR.RewriteTactics.
 From Equations Require Import Equations.
 Require Import Equations.Prop.Subterm. (* lexicographic ordering *)
 
-Require Import Coq.Program.Program.
+From Stdlib Require Import Program.Program.
 
 (* Lexicographic order used for the termination argument of reducibility *)
 (* Follows the lexicographic order definition given in Equations *)

--- a/ReducibilityOpenEquivalent.v
+++ b/ReducibilityOpenEquivalent.v
@@ -1,6 +1,6 @@
-Require Import Coq.Strings.String.
+From Stdlib Require Import String.
 Require Import Equations.Prop.Subterm.
-Require Import Psatz.
+From Stdlib Require Import Psatz.
 
 Require Export SystemFR.ReducibilityRenaming.
 Require Export SystemFR.EquivalenceLemmas2.

--- a/ReducibilityRenaming.v
+++ b/ReducibilityRenaming.v
@@ -1,10 +1,10 @@
 From Equations Require Import Equations.
 Require Import Equations.Prop.Subterm.
 
-Require Import Coq.Strings.String.
-Require Import Coq.Lists.List.
-Require Import PeanoNat.
-Require Import Psatz.
+From Stdlib Require Import String.
+From Stdlib Require Import List.
+From Stdlib Require Import PeanoNat.
+From Stdlib Require Import Psatz.
 
 Require Export SystemFR.IdRelation.
 Require Export SystemFR.RedTactics.

--- a/ReducibilitySubst.v
+++ b/ReducibilitySubst.v
@@ -1,8 +1,8 @@
 From Equations Require Import Equations.
 Require Import Equations.Prop.Subterm.
 
-Require Import Coq.Strings.String.
-Require Import Coq.Lists.List.
+From Stdlib Require Import String.
+From Stdlib Require Import List.
 
 Require Export SystemFR.ReducibilityUnused.
 Require Export SystemFR.ReducibilityIsCandidate.
@@ -10,8 +10,8 @@ Require Export SystemFR.TOpenTClose.
 Require Export SystemFR.FVLemmasClose.
 Require Export SystemFR.WFLemmasClose.
 
-Require Import PeanoNat.
-Require Import Psatz.
+From Stdlib Require Import PeanoNat.
+From Stdlib Require Import Psatz.
 
 Open Scope list_scope.
 

--- a/ReducibilityUnused.v
+++ b/ReducibilityUnused.v
@@ -1,11 +1,11 @@
 From Equations Require Import Equations.
 
-Require Import Coq.Strings.String.
+From Stdlib Require Import String.
 
 Require Export SystemFR.NoTypeFVar.
 Require Export SystemFR.ReducibilityRenaming.
 
-Require Import PeanoNat.
+From Stdlib Require Import PeanoNat.
 
 Open Scope list_scope.
 

--- a/SatisfiesLemmas.v
+++ b/SatisfiesLemmas.v
@@ -1,5 +1,5 @@
-Require Import Coq.Strings.String.
-Require Import Coq.Lists.List.
+From Stdlib Require Import String.
+From Stdlib Require Import List.
 
 Require Export SystemFR.RedTactics.
 

--- a/ShiftOpen.v
+++ b/ShiftOpen.v
@@ -357,7 +357,7 @@ Lemma shift_twice:
     shift k (shift k C i) j = shift k C (i + j).
 Proof.
   induction C;
-    repeat step || rewrite Plus.plus_assoc_reverse; eauto with lia.
+    repeat step || rewrite <- Nat.add_assoc; eauto with lia.
 Qed.
 
 Lemma open_shift_open:

--- a/ShiftOpen.v
+++ b/ShiftOpen.v
@@ -1,4 +1,4 @@
-Require Import PeanoNat.
+From Stdlib Require Import PeanoNat.
 
 Require Export SystemFR.WFLemmas.
 Require Export SystemFR.ErasedTermLemmas.

--- a/SizeLemmas.v
+++ b/SizeLemmas.v
@@ -1,7 +1,7 @@
 Require Export SystemFR.SwapTypeHoles.
 Require Export SystemFR.SwapTermHoles.
 
-Require Import Psatz.
+From Stdlib Require Import Psatz.
 
 (* measure for ensuring termination of reducible_values *)
 (* see file ReducibilityMeasure for the full measure *)

--- a/SmallStep.v
+++ b/SmallStep.v
@@ -1,5 +1,5 @@
-Require Import String.
-Require Import Relations.
+From Stdlib Require Import String.
+From Stdlib Require Import Relations.
 
 Require Export SystemFR.PrimitiveSize.
 Require Export SystemFR.PrimitiveRecognizers.

--- a/SmallStepIrredLemmas.v
+++ b/SmallStepIrredLemmas.v
@@ -1,6 +1,6 @@
 Require Export SystemFR.StarInversions.
 
-Require Import Coq.Strings.String.
+From Stdlib Require Import String.
 
 (** Lemmas about operational semantics and stuck terms.              **)
 (** At the moment, this file is not used in the rest of the proofs . **)

--- a/StarInversions.v
+++ b/StarInversions.v
@@ -1,4 +1,4 @@
-Require Import Coq.Strings.String.
+From Stdlib Require Import String.
 
 Require Export SystemFR.StarLemmas.
 

--- a/StarLemmas.v
+++ b/StarLemmas.v
@@ -1,5 +1,5 @@
-Require Import Coq.Relations.Relations.
-Require Import Coq.Relations.Relation_Operators.
+From Stdlib Require Import Relations.
+From Stdlib Require Import Relation_Operators.
 
 Require Export SystemFR.SmallStep.
 Require Export SystemFR.ListUtils.

--- a/StrictPositivity.v
+++ b/StrictPositivity.v
@@ -1,7 +1,7 @@
 From Equations Require Import Equations.
-Require Import Coq.Classes.RelationClasses.
+From Stdlib Require Import RelationClasses.
 
-Require Import Psatz.
+From Stdlib Require Import Psatz.
 
 Require Export SystemFR.SizeLemmas.
 Require Export SystemFR.NoTypeFVar.

--- a/StrictPositivityErased.v
+++ b/StrictPositivityErased.v
@@ -15,9 +15,9 @@ Require Export SystemFR.NoTypeFVarErased.
 
 Require Export SystemFR.AssocList.
 
-Require Import Coq.Lists.List.
+From Stdlib Require Import List.
 
-Require Import Psatz.
+From Stdlib Require Import Psatz.
 
 Opaque strictly_positive.
 

--- a/StrictPositivityLemma.v
+++ b/StrictPositivityLemma.v
@@ -1,10 +1,10 @@
 From Equations Require Import Equations.
 Require Import Equations.Prop.Subterm.
 
-Require Import Psatz.
+From Stdlib Require Import Psatz.
 
-Require Import Coq.Strings.String.
-Require Import Coq.Lists.List.
+From Stdlib Require Import String.
+From Stdlib Require Import List.
 
 Require Export SystemFR.ReducibilityIsCandidate.
 Require Export SystemFR.StrictPositivityLemmas.

--- a/StrictPositivityLemmas.v
+++ b/StrictPositivityLemmas.v
@@ -1,10 +1,10 @@
 From Equations Require Import Equations.
 Require Import Equations.Prop.Subterm.
 
-Require Import Psatz.
+From Stdlib Require Import Psatz.
 
-Require Import Coq.Strings.String.
-Require Import Coq.Lists.List.
+From Stdlib Require Import String.
+From Stdlib Require Import List.
 
 Require Export SystemFR.TOpenTClose.
 Require Export SystemFR.OpenTOpen.

--- a/StrictPositivityPull.v
+++ b/StrictPositivityPull.v
@@ -1,10 +1,10 @@
 From Equations Require Import Equations.
 Require Import Equations.Prop.Subterm.
 
-Require Import Psatz.
+From Stdlib Require Import Psatz.
 
-Require Import Coq.Strings.String.
-Require Import Coq.Lists.List.
+From Stdlib Require Import String.
+From Stdlib Require Import List.
 
 Require Export SystemFR.StrictPositivityLemma.
 Require Export SystemFR.ReducibilitySubst.

--- a/StrictPositivityPush.v
+++ b/StrictPositivityPush.v
@@ -1,10 +1,10 @@
 From Equations Require Import Equations.
 Require Import Equations.Prop.Subterm.
 
-Require Import Psatz.
+From Stdlib Require Import Psatz.
 
-Require Import Coq.Strings.String.
-Require Import Coq.Lists.List.
+From Stdlib Require Import String.
+From Stdlib Require Import List.
 
 Require Export SystemFR.StrictPositivityLemma.
 Require Export SystemFR.ReducibilitySubst.

--- a/StrictPositivitySubst.v
+++ b/StrictPositivitySubst.v
@@ -15,9 +15,9 @@ Require Export SystemFR.FVLemmasLists.
 
 Require Export SystemFR.AssocList.
 
-Require Import Coq.Lists.List.
+From Stdlib Require Import List.
 
-Require Import Psatz.
+From Stdlib Require Import Psatz.
 
 Opaque strictly_positive.
 

--- a/SubstitutionErase.v
+++ b/SubstitutionErase.v
@@ -1,7 +1,7 @@
 Require Export SystemFR.TreeLists.
 Require Export SystemFR.ErasedTermLemmas.
 
-Require Import PeanoNat.
+From Stdlib Require Import PeanoNat.
 
 Open Scope list_scope.
 

--- a/SubstitutionLemmas.v
+++ b/SubstitutionLemmas.v
@@ -1,5 +1,5 @@
-Require Import Coq.Lists.List.
-Require Import Coq.Arith.PeanoNat.
+From Stdlib Require Import List.
+From Stdlib Require Import PeanoNat.
 
 Require Export SystemFR.SmallStep.
 Require Export SystemFR.WFLemmas.

--- a/SwapTermHoles.v
+++ b/SwapTermHoles.v
@@ -1,5 +1,5 @@
-Require Import PeanoNat.
-Require Import Psatz.
+From Stdlib Require Import PeanoNat.
+From Stdlib Require Import Psatz.
 
 Require Export SystemFR.TWFLemmas.
 Require Export SystemFR.ErasedTermLemmas.

--- a/SwapTypeHoles.v
+++ b/SwapTypeHoles.v
@@ -1,8 +1,8 @@
 Require Export SystemFR.TWFLemmas.
 Require Export SystemFR.ErasedTermLemmas.
 
-Require Import PeanoNat.
-Require Import Psatz.
+From Stdlib Require Import PeanoNat.
+From Stdlib Require Import Psatz.
 
 Opaque PeanoNat.Nat.eq_dec.
 

--- a/Syntax.v
+++ b/Syntax.v
@@ -1,7 +1,7 @@
-Require Import Coq.Strings.String.
-Require Import Coq.Lists.List.
+From Stdlib Require Import String.
+From Stdlib Require Import List.
 
-Require Import PeanoNat.
+From Stdlib Require Import PeanoNat.
 
 Require Export SystemFR.AssocList.
 Require Export SystemFR.Trees.
@@ -127,7 +127,7 @@ Lemma fv_context_append:
   forall Γ1 Γ2 tag,
     pfv_context (Γ1 ++ Γ2) tag = pfv_context Γ1 tag ++ pfv_context Γ2 tag.
 Proof.
-  induction Γ1; repeat step || rewrite app_assoc_reverse.
+  induction Γ1; repeat step || rewrite <-app_assoc.
 Qed.
 
 #[export] Hint Rewrite fv_context_append: list_utils.

--- a/TOpenTClose.v
+++ b/TOpenTClose.v
@@ -1,5 +1,5 @@
-Require Import Coq.Strings.String.
-Require Import Psatz.
+From Stdlib Require Import String.
+From Stdlib Require Import Psatz.
 
 Require Export SystemFR.TWFLemmas.
 Require Export SystemFR.SubstitutionLemmas.

--- a/TWFLemmas.v
+++ b/TWFLemmas.v
@@ -1,6 +1,6 @@
-Require Import Coq.Strings.String.
-Require Import PeanoNat.
-Require Import Psatz.
+From Stdlib Require Import String.
+From Stdlib Require Import PeanoNat.
+From Stdlib Require Import Psatz.
 
 Require Export SystemFR.Syntax.
 

--- a/Tactics.v
+++ b/Tactics.v
@@ -1,6 +1,6 @@
-Require Import Coq.Strings.String.
-Require Import Coq.Lists.List.
-Require Import Psatz.
+From Stdlib Require Import String.
+From Stdlib Require Import List.
+From Stdlib Require Import Psatz.
 
 Open Scope string.
 

--- a/TermList.v
+++ b/TermList.v
@@ -1,6 +1,6 @@
-Require Import Coq.Strings.String.
-Require Import Coq.Lists.List.
-Require Import Coq.Arith.PeanoNat.
+From Stdlib Require Import String.
+From Stdlib Require Import List.
+From Stdlib Require Import PeanoNat.
 
 Require Export SystemFR.Syntax.
 

--- a/TermListReducible.v
+++ b/TermListReducible.v
@@ -1,4 +1,4 @@
-Require Import Coq.Lists.List.
+From Stdlib Require Import List.
 
 Require Export SystemFR.TreeLists.
 Require Export SystemFR.ReducibilityLemmas.

--- a/TypeErasure.v
+++ b/TypeErasure.v
@@ -1,7 +1,7 @@
 Require Export SystemFR.AssocList.
 Require Export SystemFR.Syntax.
 
-Require Import Coq.Strings.String.
+From Stdlib Require Import String.
 
 Open Scope list_scope.
 

--- a/TypeErasureLemmas.v
+++ b/TypeErasureLemmas.v
@@ -1,4 +1,4 @@
-Require Import Coq.Program.Tactics.
+From Stdlib Require Import Program.Tactics.
 
 Require Export SystemFR.Syntax.
 Require Export SystemFR.Tactics.

--- a/TypeOperationsErase.v
+++ b/TypeOperationsErase.v
@@ -1,4 +1,4 @@
-Require Import Coq.Strings.String.
+From Stdlib Require Import String.
 
 Require Export SystemFR.Trees.
 

--- a/TypeOperationsLemmas.v
+++ b/TypeOperationsLemmas.v
@@ -1,4 +1,4 @@
-Require Import Coq.Strings.String.
+From Stdlib Require Import String.
 
 Require Export SystemFR.Trees.
 

--- a/TypeOperationsSyntaxLemmas.v
+++ b/TypeOperationsSyntaxLemmas.v
@@ -1,4 +1,4 @@
-Require Import Coq.Strings.String.
+From Stdlib Require Import String.
 
 Require Export SystemFR.Trees.
 

--- a/TypedEquality.v
+++ b/TypedEquality.v
@@ -1,6 +1,6 @@
 From Equations Require Import Equations.
 
-Require Import Coq.Lists.List.
+From Stdlib Require Import List.
 Import ListNotations.
 
 Require Export SystemFR.TypeSugar.

--- a/TypedEqualityExamples.v
+++ b/TypedEqualityExamples.v
@@ -1,4 +1,4 @@
-Require Import List.
+From Stdlib Require Import List.
 Import ListNotations.
 
 Require Export SystemFR.TypedEquality.

--- a/Untangle.v
+++ b/Untangle.v
@@ -1,7 +1,7 @@
-Require Import Psatz.
-Require Import PeanoNat.
-Require Import Coq.Strings.String.
-Require Import Coq.Lists.List.
+From Stdlib Require Import Psatz.
+From Stdlib Require Import PeanoNat.
+From Stdlib Require Import String.
+From Stdlib Require Import List.
 
 Require Export SystemFR.ScalaDepSugar.
 Require Export SystemFR.ReducibilitySubtype.

--- a/WFLemmas.v
+++ b/WFLemmas.v
@@ -1,6 +1,6 @@
-Require Import Coq.Strings.String.
-Require Import PeanoNat.
-Require Import Psatz.
+From Stdlib Require Import String.
+From Stdlib Require Import PeanoNat.
+From Stdlib Require Import Psatz.
 
 Require Export SystemFR.Syntax.
 

--- a/WFLemmasClose.v
+++ b/WFLemmasClose.v
@@ -1,5 +1,5 @@
-Require Import Coq.Strings.String.
-Require Import Psatz.
+From Stdlib Require Import String.
+From Stdlib Require Import Psatz.
 
 Require Export SystemFR.Syntax.
 Require Export SystemFR.Tactics.

--- a/_CoqProject
+++ b/_CoqProject
@@ -1,1 +1,2 @@
 -Q . SystemFR
+-arg -w -arg -notation-incompatible-prefix

--- a/configure
+++ b/configure
@@ -1,1 +1,1 @@
-rocq makefile -Q . SystemFR *.v -o Makefile TIMED = true TIMEFMT = "\"\$*: %es\""
+rocq makefile -Q . SystemFR *.v -o Makefile

--- a/configure
+++ b/configure
@@ -1,1 +1,1 @@
-rocq makefile -Q . SystemFR *.v -o Makefile
+rocq makefile -Q . SystemFR -arg -w -arg -notation-incompatible-prefix *.v -o Makefile

--- a/configure
+++ b/configure
@@ -1,1 +1,1 @@
-coq_makefile -Q . SystemFR *.v -o Makefile TIMED = true TIMEFMT = "\"\$*: %es\""
+rocq makefile -Q . SystemFR *.v -o Makefile TIMED = true TIMEFMT = "\"\$*: %es\""

--- a/make_colored
+++ b/make_colored
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-coqdep -Q . SystemFR *.v |
+rocq dep -Q . SystemFR *.v |
   sed '/^[^.]*.vio/d' |
   sed 's/\.vo//g' |
   sed 's/[A-Za-z0-9]\+\.\(glob\|v\.beautified\|required_vo\|v\)//g' |

--- a/make_graph
+++ b/make_graph
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-coqdep -Q . SystemFR *.v |
+rocq dep -Q . SystemFR *.v |
   sed '/^[^.]*.vio/d' |
   sed 's/\.vo//g' |
   sed 's/[A-Za-z0-9]\+\.\(glob\|v\.beautified\|required_vo\|v\)//g' |


### PR DESCRIPTION
Coq has been renamed to the Rocq Prover and is now at version 9.

This PR fixes errors (884e3f55899e1c09bcc99028272f0b66c2645139) and warnings (4ce186648a60946f7723ddd47d76bc069d74058e) under Rocq 9.

Fixed warning categories:
1. `Loading Stdlib without prefix` or from `Coq` warnings → added proper prefixes
2. Deprecated notation warnings:
   - `map_length` → `length_map` (in `FVLemmasLists.v` and `AssocList.v`)
   - `app_length` → `length_app` (in `Functional.v`)
   - `rev_length` → `length_rev` (in `Existss.v`)
   - `app_assoc_reverse` → `<- app_assoc` (in `Syntax.v`)
   - `List.app_nil_end` → `List.app_nil_r` (in `ErasedList.v`)
3. `intuition` → `intros; subst; auto` (in `ListSetLemmas.v`)

There are remaining notation warnings that I could not remove. I instead disabled them (fe37131d616e95dc2dc9fbf43297698035ddd80b).

This PR also updates the Readme and scripts to use Rocq 9.0.0 (fe37131d616e95dc2dc9fbf43297698035ddd80b), adds a Dockerfile (34f80d65b32e1c9ff97293ea6b16b4200f179569) and setup GitHub Actions (c40635167cebc90f760abcb38656c121a895c5a4) to demonstrate that the project indeed still compiles after these changes 😉